### PR TITLE
[TASK] Use stable package dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
             "core/helper/Shortcuts.php"
         ]
     },
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "4.0.0-dev"


### PR DESCRIPTION
As phplist4-core does not depend on any other unreleased phpList packages,
we can use the stable versions of the dependencies. This should speed up
the build as the dependencies then change only with releases of their
packages, not with each commit, allowing for better Composer caching.