### PR TITLE
[BUGFIX] Purge the Bootstrap instance in repository integration tests

### DIFF
--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -65,6 +65,8 @@ class AdministratorTokenRepositoryTest extends TestCase
         // Destroy the tester after the test is run to keep DB connections
         // from piling up.
         $this->databaseTester = null;
+
+        Bootstrap::purgeInstance();
     }
 
     /**


### PR DESCRIPTION
This will make sure that the individual tests do not pollute each other's
environments.