### PR TITLE
[BUGFIX] Use our own repository classes

### DIFF
--- a/Classes/Domain/Model/Identity/Administrator.php
+++ b/Classes/Domain/Model/Identity/Administrator.php
@@ -10,7 +10,8 @@ use PhpList\PhpList4\Domain\Model\Traits\IdentityTrait;
  * This class represents an administrator who can log to the system, is allowed to administer
  * selected lists (as the owner), send campaigns to these lists and edit subscribers.
  *
- * @Entity @Table(name="phplist_admin")
+ * @Entity(repositoryClass="PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository")
+ * @Table(name="phplist_admin")
  *
  * @author Oliver Klee <oliver@phplist.com>
  */

--- a/Classes/Domain/Model/Identity/AdministratorToken.php
+++ b/Classes/Domain/Model/Identity/AdministratorToken.php
@@ -9,7 +9,8 @@ use PhpList\PhpList4\Domain\Model\Traits\IdentityTrait;
 /**
  * This class represents an API authentication token for an administrator.
  *
- * @Entity @Table(name="phplist_admintoken")
+ * @Entity(repositoryClass="PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository")
+ * @Table(name="phplist_admintoken")
  *
  * @author Oliver Klee <oliver@phplist.com>
  */

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -35,6 +35,14 @@ class AdministratorRepositoryTest extends AbstractRepositoryTest
     /**
      * @test
      */
+    public function instanceFromEntityManagerIsAdministratorRepository()
+    {
+        self::assertInstanceOf(AdministratorRepository::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
     public function findReadsModelFromDatabase()
     {
         $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/Fixtures/DetachedAdministrator.csv');

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -35,6 +35,14 @@ class AdministratorTokenRepositoryTest extends AbstractRepositoryTest
     /**
      * @test
      */
+    public function instanceFromEntityManagerIsAdministratorTokenRepository()
+    {
+        self::assertInstanceOf(AdministratorTokenRepository::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
     public function findReadsModelFromDatabase()
     {
         $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/Fixtures/DetachedAdministratorToken.csv');


### PR DESCRIPTION
By default, the EntityManager returns a default repository, but we want to
have our own repository class instances instead.