### PR TITLE
[BUGFIX] Close the EntityManager instance in the integration tests

### DIFF
--- a/Tests/Integration/Domain/Repository/AbstractRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/AbstractRepositoryTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace PhpList\PhpList4\Tests\Integration\Domain\Repository;
 
+use Doctrine\ORM\EntityManagerInterface;
 use PhpList\PhpList4\Core\Bootstrap;
 use PhpList\PhpList4\Domain\Model\Interfaces\Identity;
 use PHPUnit\DbUnit\Database\Connection;
@@ -41,10 +42,17 @@ abstract class AbstractRepositoryTest extends TestCase
      */
     protected $bootstrap = null;
 
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager = null;
+
     protected function setUp()
     {
         $this->bootstrap = Bootstrap::getInstance()->activateDevelopmentMode()->configure();
         $this->initializeDatabaseTester();
+        $this->entityManager = $this->bootstrap->getEntityManager();
+        self::assertTrue($this->entityManager->isOpen());
     }
 
     /**
@@ -62,6 +70,7 @@ abstract class AbstractRepositoryTest extends TestCase
 
     protected function tearDown()
     {
+        $this->entityManager->close();
         $this->getDatabaseTester()->setTearDownOperation($this->getTearDownOperation());
         $this->getDatabaseTester()->setDataSet($this->getDataSet());
         $this->getDatabaseTester()->onTearDown();

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace PhpList\PhpList4\Tests\Integration\Domain\Repository\Identity;
 
 use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use PhpList\PhpList4\Domain\Model\Identity\Administrator;
 use PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository;
 use PhpList\PhpList4\Tests\Integration\Domain\Repository\AbstractRepositoryTest;
@@ -25,11 +26,16 @@ class AdministratorRepositoryTest extends AbstractRepositoryTest
      */
     private $subject = null;
 
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager = null;
+
     protected function setUp()
     {
         parent::setUp();
 
-        $this->subject = $this->bootstrap->getEntityManager()->getRepository(Administrator::class);
+        $this->subject = $this->entityManager->getRepository(Administrator::class);
     }
 
     /**

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -29,7 +29,7 @@ class AdministratorTokenRepositoryTest extends AbstractRepositoryTest
     {
         parent::setUp();
 
-        $this->subject = $this->bootstrap->getEntityManager()->getRepository(AdministratorToken::class);
+        $this->subject = $this->entityManager->getRepository(AdministratorToken::class);
     }
 
     /**


### PR DESCRIPTION
This will ensure that one test cannot try to use an EntityManager from a
previous test.