### PR TITLE
[TASK] Remove the normalized user name

### DIFF
--- a/Classes/Domain/Model/Identity/Administrator.php
+++ b/Classes/Domain/Model/Identity/Administrator.php
@@ -28,12 +28,6 @@ class Administrator implements Identity
 
     /**
      * @var string
-     * @Column(name="namelc")
-     */
-    private $normalizedLoginName = '';
-
-    /**
-     * @var string
      * @Column(name="email")
      */
     private $emailAddress = '';
@@ -84,24 +78,6 @@ class Administrator implements Identity
     public function setLoginName(string $loginName)
     {
         $this->loginName = $loginName;
-    }
-
-    /**
-     * @return string
-     */
-    public function getNormalizedLoginName(): string
-    {
-        return $this->normalizedLoginName;
-    }
-
-    /**
-     * @param string $normalizedLoginName
-     *
-     * @return void
-     */
-    public function setNormalizedLoginName(string $normalizedLoginName)
-    {
-        $this->normalizedLoginName = $normalizedLoginName;
     }
 
     /**

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -66,7 +66,6 @@ class AdministratorRepositoryTest extends AbstractRepositoryTest
 
         self::assertSame($id, $actualModel->getId());
         self::assertSame($loginName, $actualModel->getLoginName());
-        self::assertSame($normalizedLoginName, $actualModel->getNormalizedLoginName());
         self::assertSame($emailAddress, $actualModel->getEmailAddress());
         self::assertEquals($creationDate, $actualModel->getCreationDate());
         self::assertEquals($modificationDate, $actualModel->getModificationDate());

--- a/Tests/Integration/Domain/Repository/Identity/Fixtures/Administrator.csv
+++ b/Tests/Integration/Domain/Repository/Identity/Fixtures/Administrator.csv
@@ -1,2 +1,2 @@
-id,loginname,namelc,email,created,modified,password,passwordchanged,disabled
-1,"john.doe","john-doe","john@example.com","2017-06-22 15:01:17","2017-06-23 19:50:43","1491a3c7e7b23b9a6393323babbb095dee0d7d81b2199617b487bd0fb5236f3c","2017-06-28",1
+id,loginname,email,created,modified,password,passwordchanged,disabled
+1,"john.doe","john@example.com","2017-06-22 15:01:17","2017-06-23 19:50:43","1491a3c7e7b23b9a6393323babbb095dee0d7d81b2199617b487bd0fb5236f3c","2017-06-28",1

--- a/Tests/Unit/Domain/Model/Identity/AdministratorTest.php
+++ b/Tests/Unit/Domain/Model/Identity/AdministratorTest.php
@@ -69,25 +69,6 @@ class AdministratorTest extends TestCase
     /**
      * @test
      */
-    public function getNormalizedLoginNameInitiallyReturnsEmptyString()
-    {
-        self::assertSame('', $this->subject->getNormalizedLoginName());
-    }
-
-    /**
-     * @test
-     */
-    public function setNormalizedLoginNameSetsNormalizedLoginName()
-    {
-        $value = 'jane-doe';
-        $this->subject->setNormalizedLoginName($value);
-
-        self::assertSame($value, $this->subject->getNormalizedLoginName());
-    }
-
-    /**
-     * @test
-     */
     public function getEmailAddressInitiallyReturnsEmptyString()
     {
         self::assertSame('', $this->subject->getEmailAddress());


### PR DESCRIPTION
We can always use the "normal" user name instead.