### PR TITLE
[TASK] Make AdministratorToken.setExpiry private

### DIFF
--- a/Classes/Domain/Model/Identity/AdministratorToken.php
+++ b/Classes/Domain/Model/Identity/AdministratorToken.php
@@ -64,9 +64,19 @@ class AdministratorToken implements Identity
      *
      * @return void
      */
-    public function setExpiry(\DateTime $expiry)
+    private function setExpiry(\DateTime $expiry)
     {
         $this->expiry = $expiry;
+    }
+
+    /**
+     * Generates and sets an expiry one hour in the future.
+     *
+     * @return void
+     */
+    public function generateExpiry()
+    {
+        $this->setExpiry(new \DateTime(self::DEFAULT_EXPIRY));
     }
 
     /**
@@ -96,16 +106,6 @@ class AdministratorToken implements Identity
     {
         $key = md5(random_bytes(256));
         $this->setKey($key);
-    }
-
-    /**
-     * Generates and sets an expiry one hour in the future.
-     *
-     * @return void
-     */
-    public function generateExpiry()
-    {
-        $this->setExpiry(new \DateTime(self::DEFAULT_EXPIRY));
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Identity/AdministratorTokenTest.php
+++ b/Tests/Unit/Domain/Model/Identity/AdministratorTokenTest.php
@@ -78,17 +78,6 @@ class AdministratorTokenTest extends TestCase
     /**
      * @test
      */
-    public function setExpirySetsExpiry()
-    {
-        $expiry = new \DateTime();
-        $this->subject->setExpiry($expiry);
-
-        self::assertSame($expiry, $this->subject->getExpiry());
-    }
-
-    /**
-     * @test
-     */
     public function generateExpirySetsExpiryOneHourInTheFuture()
     {
         $this->subject->generateExpiry();


### PR DESCRIPTION
The expiry should always be generated via generateExpiry, not be set
directly.

Also move the generateExpiry method to directly below setExpiry.