### PR TITLE
[CLEANUP] Remove obsolete dependencies from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,7 @@
 
         "roave/security-advisories": "dev-master",
 
-        "doctrine/orm": "^2.5.6",
-
-        "symfony/dependency-injection": "^3.3.2",
-        "symfony/yaml": "^3.3.2",
-        "symfony/config": "^3.3.2",
-        "phpmailer/phpmailer": "^v5.2.23",
-        "psr/log": "^1.0.2"
+        "doctrine/orm": "^2.5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2.2",


### PR DESCRIPTION
Remove all dependencies that are not needed for the current set of
automated tests.

We will re-add any dependencies once they are needed for the new code.

This will speed up the builds and the installation process.