### PR TITLE
[BUGFIX] Import the DB structure after the composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,16 @@ cache:
 
 before_install:
   - phpenv config-rm xdebug.ini
+
+install:
+  - composer install
+
+before_script:
   - >
     echo;
     echo "Importing the database schema";
     mysql -e "CREATE DATABASE ${PHPLIST_DATABASE_NAME};";
     mysql ${PHPLIST_DATABASE_NAME} < Database/Schema.sql;
-
-install:
-  - composer install
 
 script:
   - >


### PR DESCRIPTION
This make the order of the steps for the Travis builds consistent with
the rest-api package (where this order is needed to fix the broken build).