### PR TITLE
[BUGFIX] Lock the Travis builds to Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 matrix:
   include:
   - php: 7.0


### PR DESCRIPTION
This will avoid failures when getting a build on Trusty.