### PR TITLE
[CLEANUP] Move getApplicationRoot to a separate class

### DIFF
--- a/Classes/Core/ApplicationKernel.php
+++ b/Classes/Core/ApplicationKernel.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpKernel\Kernel;
 class ApplicationKernel extends Kernel
 {
     /**
-     * @var string
+     * @var ApplicationStructure
      */
-    private $projectDir = '';
+    private $applicationStructure = null;
 
     /**
      * @return BundleInterface[]
@@ -47,17 +47,7 @@ class ApplicationKernel extends Kernel
      */
     public function getProjectDir(): string
     {
-        return $this->projectDir;
-    }
-
-    /**
-     * @param string $directory
-     *
-     * @return void
-     */
-    public function setProjectDir(string $directory)
-    {
-        $this->projectDir = $directory;
+        return $this->getAndCreateApplicationStructure()->getApplicationRoot();
     }
 
     /**
@@ -65,7 +55,19 @@ class ApplicationKernel extends Kernel
      */
     public function getRootDir(): string
     {
-        return dirname(__DIR__, 2);
+        return $this->getProjectDir();
+    }
+
+    /**
+     * @return ApplicationStructure
+     */
+    private function getAndCreateApplicationStructure(): ApplicationStructure
+    {
+        if ($this->applicationStructure === null) {
+            $this->applicationStructure = new ApplicationStructure();
+        }
+
+        return $this->applicationStructure;
     }
 
     /**

--- a/Classes/Core/ApplicationStructure.php
+++ b/Classes/Core/ApplicationStructure.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Core;
+
+/**
+ * This class provides information about the current application and its file structure.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+class ApplicationStructure
+{
+    /**
+     * Returns the absolute path to the application root.
+     *
+     * When phplist4-core is installed as a dependency (library) of an application, this method will return
+     * the application's package path.
+     *
+     * When phpList4-core is installed stand-alone (i.e., as an application - usually only for testing),
+     * this method will be the phpList4-core package path.
+     *
+     * @return string the absolute path without the trailing slash.
+     *
+     * @throws \RuntimeException if there is no composer.json in the application root
+     */
+    public function getApplicationRoot(): string
+    {
+        $corePackagePath = dirname(__DIR__, 2);
+        $corePackageIsRootPackage = interface_exists('PhpList\\PhpList4\\Tests\\Support\\Interfaces\\TestMarker');
+        if ($corePackageIsRootPackage) {
+            $applicationRoot = $corePackagePath;
+        } else {
+            // remove 3 more path segments, i.e., "vendor/phplist/phplist4-core/"
+            $corePackagePath = dirname($corePackagePath, 3);
+            $applicationRoot = $corePackagePath;
+        }
+
+        if (!file_exists($applicationRoot . '/composer.json')) {
+            throw new \RuntimeException(
+                'There is no composer.json in the supposed application root "' . $applicationRoot . '".',
+                1501169001588
+            );
+        }
+
+        return $applicationRoot;
+    }
+}

--- a/Classes/Core/Bootstrap.php
+++ b/Classes/Core/Bootstrap.php
@@ -87,12 +87,18 @@ class Bootstrap
     private $applicationKernel = null;
 
     /**
+     * @var ApplicationStructure
+     */
+    private $applicationStructure = null;
+
+    /**
      * Protected constructor to avoid direct instantiation of this class.
      *
      * Please use getInstance instead.
      */
     protected function __construct()
     {
+        $this->applicationStructure = new ApplicationStructure();
     }
 
     /**
@@ -305,7 +311,6 @@ class Bootstrap
             $this->getApplicationContext(),
             $this->isSymfonyDebugModeEnabled()
         );
-        $this->applicationKernel->setProjectDir($this->getApplicationRoot());
 
         return $this;
     }
@@ -349,23 +354,6 @@ class Bootstrap
      */
     public function getApplicationRoot(): string
     {
-        $corePackagePath = dirname(__DIR__, 2);
-        $corePackageIsRootPackage = interface_exists('PhpList\\PhpList4\\Tests\\Support\\Interfaces\\TestMarker');
-        if ($corePackageIsRootPackage) {
-            $applicationRoot = $corePackagePath;
-        } else {
-            // remove 3 more path segments, i.e., "vendor/phplist/phplist4-core/"
-            $corePackagePath = dirname($corePackagePath, 3);
-            $applicationRoot = $corePackagePath;
-        }
-
-        if (!file_exists($applicationRoot . '/composer.json')) {
-            throw new \RuntimeException(
-                'There is no composer.json in the supposed application root "' . $applicationRoot . '".',
-                1501169001588
-            );
-        }
-
-        return $applicationRoot;
+        return $this->applicationStructure->getApplicationRoot();
     }
 }

--- a/Tests/Integration/Core/ApplicationKernelTest.php
+++ b/Tests/Integration/Core/ApplicationKernelTest.php
@@ -1,12 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace PhpList\PhpList4\Tests\Unit\Core;
+namespace PhpList\PhpList4\Tests\Integration\Core;
 
 use PhpList\PhpList4\Core\ApplicationKernel;
 use PhpList\PhpList4\Core\Bootstrap;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Testcase.
@@ -33,8 +32,16 @@ class ApplicationKernelTest extends TestCase
     /**
      * @test
      */
-    public function isKernelInstance()
+    public function getProjectDirReturnsApplicationRoot()
     {
-        self::assertInstanceOf(Kernel::class, $this->subject);
+        self::assertSame(dirname(__DIR__, 3), $this->subject->getProjectDir());
+    }
+
+    /**
+     * @test
+     */
+    public function getRootDirReturnsApplicationRoot()
+    {
+        self::assertSame(dirname(__DIR__, 3), $this->subject->getRootDir());
     }
 }

--- a/Tests/Integration/Core/BootstrapTest.php
+++ b/Tests/Integration/Core/BootstrapTest.php
@@ -36,4 +36,12 @@ class BootstrapTest extends TestCase
     {
         self::assertSame($this->subject, $this->subject->preventProductionEnvironment());
     }
+
+    /**
+     * @test
+     */
+    public function getApplicationRootReturnsCoreApplicationRoot()
+    {
+        self::assertSame(dirname(__DIR__, 3), $this->subject->getApplicationRoot());
+    }
 }

--- a/Tests/Unit/Core/ApplicationStructureTest.php
+++ b/Tests/Unit/Core/ApplicationStructureTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Tests\Unit\Core;
+
+use PhpList\PhpList4\Core\ApplicationStructure;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testcase.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+class ApplicationStructureTest extends TestCase
+{
+    /**
+     * @var ApplicationStructure
+     */
+    private $subject = null;
+
+    protected function setUp()
+    {
+        $this->subject = new ApplicationStructure();
+    }
+
+    /**
+     * @test
+     */
+    public function getApplicationRootReturnsCoreApplicationRoot()
+    {
+        self::assertSame(dirname(__DIR__, 3), $this->subject->getApplicationRoot());
+    }
+}

--- a/Tests/Unit/Core/BootstrapTest.php
+++ b/Tests/Unit/Core/BootstrapTest.php
@@ -165,34 +165,6 @@ class BootstrapTest extends TestCase
     /**
      * @test
      */
-    public function getApplicationRootReturnsCoreApplicationRoot()
-    {
-        self::assertSame($this->getApplicationRoot(), $this->subject->getApplicationRoot());
-    }
-
-    /**
-     * @return string
-     */
-    private function getApplicationRoot(): string
-    {
-        return dirname(__DIR__, 3);
-    }
-
-    /**
-     * @test
-     */
-    public function configureSetsApplicationKernelProjectDirToApplicationRoot()
-    {
-        $this->subject->configure();
-
-        $applicationKernel = $this->subject->getApplicationKernel();
-
-        self::assertSame($this->getApplicationRoot(), $applicationKernel->getProjectDir());
-    }
-
-    /**
-     * @test
-     */
     public function dispatchWithoutConfigureThrowsException()
     {
         $this->expectException(\RuntimeException::class);


### PR DESCRIPTION
This method needs to be (indirectly) called from the ApplicationKernel
constructor, making setting the application root from the Bootstrap class
impossible.

In addition, this method will be needed in the Composer ScriptHandler class,
which should not need to bootstrap the application.