### PR TITLE
[BUGFIX] Symfony project root always needs to be the core package root

### DIFF
--- a/Classes/Core/ApplicationKernel.php
+++ b/Classes/Core/ApplicationKernel.php
@@ -47,7 +47,7 @@ class ApplicationKernel extends Kernel
      */
     public function getProjectDir(): string
     {
-        return $this->getAndCreateApplicationStructure()->getApplicationRoot();
+        return $this->getAndCreateApplicationStructure()->getCorePackageRoot();
     }
 
     /**

--- a/Classes/Core/ApplicationStructure.php
+++ b/Classes/Core/ApplicationStructure.php
@@ -11,6 +11,18 @@ namespace PhpList\PhpList4\Core;
 class ApplicationStructure
 {
     /**
+     * Returns the absolute path to the phplist4-core package root.
+     *
+     * @return string the absolute path without the trailing slash.
+     *
+     * @throws \RuntimeException if there is no composer.json in the application root
+     */
+    public function getCorePackageRoot(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+
+    /**
      * Returns the absolute path to the application root.
      *
      * When phplist4-core is installed as a dependency (library) of an application, this method will return
@@ -25,7 +37,7 @@ class ApplicationStructure
      */
     public function getApplicationRoot(): string
     {
-        $corePackagePath = dirname(__DIR__, 2);
+        $corePackagePath = $this->getCorePackageRoot();
         $corePackageIsRootPackage = interface_exists('PhpList\\PhpList4\\Tests\\Support\\Interfaces\\TestMarker');
         if ($corePackageIsRootPackage) {
             $applicationRoot = $corePackagePath;

--- a/Tests/Integration/Core/ApplicationKernelTest.php
+++ b/Tests/Integration/Core/ApplicationKernelTest.php
@@ -32,7 +32,7 @@ class ApplicationKernelTest extends TestCase
     /**
      * @test
      */
-    public function getProjectDirReturnsApplicationRoot()
+    public function getProjectDirReturnsCorePackacgeRoot()
     {
         self::assertSame(dirname(__DIR__, 3), $this->subject->getProjectDir());
     }
@@ -40,7 +40,7 @@ class ApplicationKernelTest extends TestCase
     /**
      * @test
      */
-    public function getRootDirReturnsApplicationRoot()
+    public function getRootDirReturnsCorePackacgeRoot()
     {
         self::assertSame(dirname(__DIR__, 3), $this->subject->getRootDir());
     }

--- a/Tests/Unit/Core/ApplicationStructureTest.php
+++ b/Tests/Unit/Core/ApplicationStructureTest.php
@@ -30,4 +30,12 @@ class ApplicationStructureTest extends TestCase
     {
         self::assertSame(dirname(__DIR__, 3), $this->subject->getApplicationRoot());
     }
+
+    /**
+     * @test
+     */
+    public function getCorePackageRootReturnsCorePackageRoot()
+    {
+        self::assertSame(dirname(__DIR__, 3), $this->subject->getCorePackageRoot());
+    }
 }


### PR DESCRIPTION
The term "project root" is misleading for cases where the application kernel
comes from a dependency (as it is the case with phpList 4).

This change is necessary so packages like rest-api still can load the core
configuration.