### PR TITLE
[CLEANUP] Add an Environment class

### DIFF
--- a/Classes/Core/Bootstrap.php
+++ b/Classes/Core/Bootstrap.php
@@ -13,9 +13,9 @@ use Symfony\Component\HttpFoundation\Request;
  * This class bootstraps the phpList core system.
  *
  * Include it from the entry point and call Bootstrap::getInstance() to get an instance,
- * and $bootstrap->setApplicationContext($context) if you would like to run the application in
- * the development or testing context. (For the production context, the setApplicationContext call
- * is not needed).
+ * and $bootstrap->setEnvironment($environment) if you would like to run the application in
+ * the development or testing environment. (For the production environment,
+ * the setEnvironment call is not needed).
  *
  * After that, call $bootstrap->configure() and $bootstrap->dispatch().
  *
@@ -26,41 +26,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class Bootstrap
 {
-    /**
-     * application context for running a live site
-     *
-     * @var string
-     */
-    const APPLICATION_CONTEXT_PRODUCTION = 'prod';
-
-    /**
-     * application context for developing locally
-     *
-     * @var string
-     */
-    const APPLICATION_CONTEXT_DEVELOPMENT = 'dev';
-
-    /**
-     * application context for running automated tests
-     *
-     * @var string
-     */
-    const APPLICATION_CONTEXT_TESTING = 'test';
-
-    /**
-     * @var string
-     */
-    const DEFAULT_APPLICATION_CONTEXT = self::APPLICATION_CONTEXT_PRODUCTION;
-
-    /**
-     * @var string[]
-     */
-    private static $validApplicationContexts = [
-        self::APPLICATION_CONTEXT_PRODUCTION,
-        self::APPLICATION_CONTEXT_DEVELOPMENT,
-        self::APPLICATION_CONTEXT_TESTING,
-    ];
-
     /**
      * @var Bootstrap|null
      */
@@ -74,7 +39,7 @@ class Bootstrap
     /**
      * @var string
      */
-    private $applicationContext = self::DEFAULT_APPLICATION_CONTEXT;
+    private $environment = Environment::DEFAULT_ENVIRONMENT;
 
     /**
      * @var EntityManager
@@ -135,22 +100,16 @@ class Bootstrap
     }
 
     /**
-     * @param string $context must be one of the APPLICATION_CONTEXT_* constants
+     * @param string $environment must be one of the Environment::* constants
      *
      * @return Bootstrap fluent interface
      *
      * @throws \UnexpectedValueException
      */
-    public function setApplicationContext(string $context): Bootstrap
+    public function setEnvironment(string $environment): Bootstrap
     {
-        if (!in_array($context, self::$validApplicationContexts, true)) {
-            throw new \UnexpectedValueException(
-                '$context must be one of "Production", "Development", or "Testing", but actually is: ' . $context,
-                1499112172108
-            );
-        }
-
-        $this->applicationContext = $context;
+        Environment::validateEnvironment($environment);
+        $this->environment = $environment;
 
         return $this;
     }
@@ -158,9 +117,9 @@ class Bootstrap
     /**
      * @return string
      */
-    public function getApplicationContext(): string
+    public function getEnvironment(): string
     {
-        return $this->applicationContext;
+        return $this->environment;
     }
 
     /**
@@ -168,7 +127,7 @@ class Bootstrap
      */
     private function isDoctrineOrmDevelopmentModeEnabled(): bool
     {
-        return $this->applicationContext !== self::APPLICATION_CONTEXT_PRODUCTION;
+        return $this->environment !== Environment::PRODUCTION;
     }
 
     /**
@@ -176,7 +135,7 @@ class Bootstrap
      */
     private function isSymfonyDebugModeEnabled(): bool
     {
-        return $this->applicationContext !== self::APPLICATION_CONTEXT_PRODUCTION;
+        return $this->environment !== Environment::PRODUCTION;
     }
 
     /**
@@ -184,7 +143,7 @@ class Bootstrap
      */
     private function isDebugEnabled(): bool
     {
-        return $this->applicationContext !== self::APPLICATION_CONTEXT_PRODUCTION;
+        return $this->environment !== Environment::PRODUCTION;
     }
 
     /**
@@ -308,7 +267,7 @@ class Bootstrap
     private function configureApplicationKernel(): Bootstrap
     {
         $this->applicationKernel = new ApplicationKernel(
-            $this->getApplicationContext(),
+            $this->getEnvironment(),
             $this->isSymfonyDebugModeEnabled()
         );
 

--- a/Classes/Core/Environment.php
+++ b/Classes/Core/Environment.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Core;
+
+/**
+ * This class provides methods and constants for the application environment/context.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+final class Environment
+{
+    /**
+     * environment for running a live site
+     *
+     * @var string
+     */
+    const PRODUCTION = 'prod';
+
+    /**
+     * environment for developing locally
+     *
+     * @var string
+     */
+    const DEVELOPMENT = 'dev';
+
+    /**
+     * environment for running automated tests
+     *
+     * @var string
+     */
+    const TESTING = 'test';
+
+    /**
+     * @var string
+     */
+    const DEFAULT_ENVIRONMENT = self::PRODUCTION;
+
+    /**
+     * @var string[]
+     */
+    private static $validEnvironments = [self::PRODUCTION, self::DEVELOPMENT, self::TESTING];
+
+    /**
+     * Private constructor to avoid instantiation.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Validates that $environment is a valid environment, and throws an exception otherwise.
+     *
+     * @param string $environment must be one of the environment constants
+     *
+     * @return void
+     *
+     * @throws \UnexpectedValueException
+     */
+    public static function validateEnvironment(string $environment)
+    {
+        if (!in_array($environment, self::$validEnvironments, true)) {
+            $environmentsText = '"' . implode('", ', self::$validEnvironments) . '"';
+            throw new \UnexpectedValueException(
+                '$environment must be one of ' . $environmentsText . ', but actually was: "' . $environment . '"',
+                1499112172108
+            );
+        }
+    }
+}

--- a/Configuration/PHPMD/rules.xml
+++ b/Configuration/PHPMD/rules.xml
@@ -9,7 +9,7 @@
     <rule ref="rulesets/cleancode.xml/StaticAccess">
         <properties>
             <property name="exceptions"
-                      value="\Doctrine\ORM\EntityManager,\Doctrine\ORM\Tools\Setup,\Symfony\Component\Debug\Debug"/>
+                      value="\Doctrine\ORM\EntityManager,\Doctrine\ORM\Tools\Setup,\Symfony\Component\Debug\Debug,PhpList\PhpList4\Core\Environment"/>
         </properties>
     </rule>
 

--- a/Tests/Integration/ApplicationBundle/Controller/DefaultControllerTest.php
+++ b/Tests/Integration/ApplicationBundle/Controller/DefaultControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace PhpList\PhpList4\Tests\Integration\ApplicationBundle\Controller;
 
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -21,9 +22,9 @@ class DefaultControllerTest extends WebTestCase
 
     protected function setUp()
     {
-        Bootstrap::getInstance()->setApplicationContext(Bootstrap::APPLICATION_CONTEXT_TESTING)->configure();
+        Bootstrap::getInstance()->setEnvironment(Environment::TESTING)->configure();
 
-        $this->client = self::createClient(['environment' => Bootstrap::APPLICATION_CONTEXT_TESTING]);
+        $this->client = self::createClient(['environment' => Environment::TESTING]);
     }
 
     /**

--- a/Tests/Integration/Core/ApplicationKernelTest.php
+++ b/Tests/Integration/Core/ApplicationKernelTest.php
@@ -5,6 +5,7 @@ namespace PhpList\PhpList4\Tests\Integration\Core;
 
 use PhpList\PhpList4\Core\ApplicationKernel;
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +22,7 @@ class ApplicationKernelTest extends TestCase
 
     protected function setUp()
     {
-        $this->subject = new ApplicationKernel(Bootstrap::APPLICATION_CONTEXT_TESTING, true);
+        $this->subject = new ApplicationKernel(Environment::TESTING, true);
     }
 
     protected function tearDown()
@@ -67,7 +68,7 @@ class ApplicationKernelTest extends TestCase
     public function getCacheDirReturnsEnvironmentSpecificVarCacheDirectoryInApplicationRoot()
     {
         self::assertSame(
-            $this->getApplicationRoot() . '/var/cache/' . Bootstrap::APPLICATION_CONTEXT_TESTING,
+            $this->getApplicationRoot() . '/var/cache/' . Environment::TESTING,
             $this->subject->getCacheDir()
         );
     }

--- a/Tests/Integration/Core/BootstrapTest.php
+++ b/Tests/Integration/Core/BootstrapTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace PhpList\PhpList4\Tests\Integration\Core;
 
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +22,7 @@ class BootstrapTest extends TestCase
     protected function setUp()
     {
         $this->subject = Bootstrap::getInstance();
-        $this->subject->setApplicationContext(Bootstrap::APPLICATION_CONTEXT_TESTING);
+        $this->subject->setEnvironment(Environment::TESTING);
     }
 
     protected function tearDown()

--- a/Tests/Integration/Domain/Repository/AbstractRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/AbstractRepositoryTest.php
@@ -5,6 +5,7 @@ namespace PhpList\PhpList4\Tests\Integration\Domain\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 use PhpList\PhpList4\Domain\Model\Interfaces\Identity;
 use PHPUnit\DbUnit\Database\Connection;
 use PHPUnit\DbUnit\DataSet\CsvDataSet;
@@ -50,8 +51,7 @@ abstract class AbstractRepositoryTest extends TestCase
     protected function setUp()
     {
         $this->initializeDatabaseTester();
-        $this->bootstrap = Bootstrap::getInstance()->setApplicationContext(Bootstrap::APPLICATION_CONTEXT_TESTING)
-            ->configure();
+        $this->bootstrap = Bootstrap::getInstance()->setEnvironment(Environment::TESTING)->configure();
         $this->entityManager = $this->bootstrap->getEntityManager();
         self::assertTrue($this->entityManager->isOpen());
     }

--- a/Tests/Unit/Core/ApplicationKernelTest.php
+++ b/Tests/Unit/Core/ApplicationKernelTest.php
@@ -5,6 +5,7 @@ namespace PhpList\PhpList4\Tests\Unit\Core;
 
 use PhpList\PhpList4\Core\ApplicationKernel;
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -22,7 +23,7 @@ class ApplicationKernelTest extends TestCase
 
     protected function setUp()
     {
-        $this->subject = new ApplicationKernel(Bootstrap::APPLICATION_CONTEXT_TESTING, true);
+        $this->subject = new ApplicationKernel(Environment::TESTING, true);
     }
 
     protected function tearDown()

--- a/Tests/Unit/Core/BootstrapTest.php
+++ b/Tests/Unit/Core/BootstrapTest.php
@@ -6,6 +6,7 @@ namespace PhpList\PhpList4\Tests\Unit\Core;
 use Doctrine\ORM\EntityManagerInterface;
 use PhpList\PhpList4\Core\ApplicationKernel;
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,7 +24,7 @@ class BootstrapTest extends TestCase
     protected function setUp()
     {
         $this->subject = Bootstrap::getInstance();
-        $this->subject->setApplicationContext(Bootstrap::APPLICATION_CONTEXT_TESTING);
+        $this->subject->setEnvironment(Environment::TESTING);
     }
 
     protected function tearDown()
@@ -63,55 +64,55 @@ class BootstrapTest extends TestCase
     /**
      * @test
      */
-    public function applicationContextIsProductionByDefault()
+    public function environmentIsProductionByDefault()
     {
         Bootstrap::purgeInstance();
 
         $subject = Bootstrap::getInstance();
 
-        self::assertSame(Bootstrap::APPLICATION_CONTEXT_PRODUCTION, $subject->getApplicationContext());
+        self::assertSame(Environment::PRODUCTION, $subject->getEnvironment());
     }
 
     /**
      * @test
      */
-    public function setApplicationContextHasFluentInterface()
+    public function setEnvironmentHasFluentInterface()
     {
-        self::assertSame($this->subject, $this->subject->setApplicationContext(Bootstrap::APPLICATION_CONTEXT_TESTING));
+        self::assertSame($this->subject, $this->subject->setEnvironment(Environment::TESTING));
     }
 
     /**
      * @return string[][]
      */
-    public function validApplicationContextDataProvider(): array
+    public function validEnvironmentDataProvider(): array
     {
         return [
-            'Production' => [Bootstrap::APPLICATION_CONTEXT_PRODUCTION],
-            'Development' => [Bootstrap::APPLICATION_CONTEXT_DEVELOPMENT],
-            'Testing' => [Bootstrap::APPLICATION_CONTEXT_TESTING],
+            'Production' => [Environment::PRODUCTION],
+            'Development' => [Environment::DEVELOPMENT],
+            'Testing' => [Environment::TESTING],
         ];
     }
 
     /**
      * @test
-     * @param string $context
-     * @dataProvider validApplicationContextDataProvider
+     * @param string $environment
+     * @dataProvider validEnvironmentDataProvider
      */
-    public function setApplicationContextWithValidContextSetsContext(string $context)
+    public function setEnvironmentWithValidEnvironmentSetsEnvironment(string $environment)
     {
-        $this->subject->setApplicationContext($context);
+        $this->subject->setEnvironment($environment);
 
-        self::assertSame($context, $this->subject->getApplicationContext());
+        self::assertSame($environment, $this->subject->getEnvironment());
     }
 
     /**
      * @test
      */
-    public function setApplicationContextWithInvalidContextThrowsException()
+    public function setEnvironmentWithInvalidEnvironmentThrowsException()
     {
         $this->expectException(\UnexpectedValueException::class);
 
-        $this->subject->setApplicationContext('Reckless');
+        $this->subject->setEnvironment('Reckless');
     }
 
     /**

--- a/Tests/Unit/Core/EnvironmentTest.php
+++ b/Tests/Unit/Core/EnvironmentTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Tests\Unit\Core;
+
+use PhpList\PhpList4\Core\Environment;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testcase.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+class EnvironmentTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function defaultEnvironmentIsProduction()
+    {
+        self::assertSame(Environment::PRODUCTION, Environment::DEFAULT_ENVIRONMENT);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function validEnvironmentDataProvider(): array
+    {
+        return [
+            'Production' => [Environment::PRODUCTION],
+            'Development' => [Environment::DEVELOPMENT],
+            'Testing' => [Environment::TESTING],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $environment
+     * @dataProvider validEnvironmentDataProvider
+     */
+    public function validateEnvironmentForValidEnvironmentPasses(string $environment)
+    {
+        Environment::validateEnvironment($environment);
+
+        // This is to avoid a warning in PHPUnit that this test has no assertions (as there is no assertion
+        // for "no exception is thrown").
+        self::assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function validateEnvironmentForInvalidEnvironmentThrowsException()
+    {
+        $environment = 'home';
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('$environment must be one of "prod", dev", test", but actually was: "home"');
+
+        Environment::validateEnvironment($environment);
+    }
+}

--- a/bin/console
+++ b/bin/console
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PhpList\PhpList4\Core\ApplicationKernel;
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
@@ -13,14 +14,15 @@ set_time_limit(0);
 require __DIR__ . '/../vendor/autoload.php';
 
 $input = new ArgvInput();
-$context = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
-$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', '']) && $context !== 'prod';
+$environment = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: Environment::DEVELOPMENT);
+$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', ''])
+    && $environment !== Environment::PRODUCTION;
 
 if ($debug) {
     Debug::enable();
 }
 
-Bootstrap::getInstance()->setApplicationContext($context)->configure();
-$kernel = new ApplicationKernel($context, $debug);
+Bootstrap::getInstance()->setEnvironment($environment)->configure();
+$kernel = new ApplicationKernel($environment, $debug);
 $application = new Application($kernel);
 $application->run($input);

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -2,11 +2,12 @@
 declare(strict_types=1);
 
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 Bootstrap::getInstance()
     ->preventProductionEnvironment()
-    ->setApplicationContext(Bootstrap::APPLICATION_CONTEXT_DEVELOPMENT)
+    ->setEnvironment(Environment::DEVELOPMENT)
     ->configure()
     ->dispatch();

--- a/web/app_test.php
+++ b/web/app_test.php
@@ -2,11 +2,12 @@
 declare(strict_types=1);
 
 use PhpList\PhpList4\Core\Bootstrap;
+use PhpList\PhpList4\Core\Environment;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 Bootstrap::getInstance()
     ->preventProductionEnvironment()
-    ->setApplicationContext(Bootstrap::APPLICATION_CONTEXT_TESTING)
+    ->setEnvironment(Environment::TESTING)
     ->configure()
     ->dispatch();


### PR DESCRIPTION
This resolves a circular dependency between Bootstrap and ApplicationKernel.

Also unify the terminology from "application context" to "environment" to
be closer to Symfony conventions.