### PR TITLE
[CLEANUP] Follow the Symfony configuration conventions more closely

### DIFF
--- a/Configuration/config.yml
+++ b/Configuration/config.yml
@@ -1,0 +1,33 @@
+imports:
+    - { resource: parameters.yml }
+    - { resource: services.yml }
+
+# Put parameters here that don't need to change on each machine where the app is deployed
+# https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
+parameters:
+    locale: en
+
+framework:
+    #esi: ~
+    #translator: { fallbacks: ['%locale%'] }
+    secret: '%secret%'
+    router:
+        resource: '%kernel.project_dir%/Configuration/routing.yml'
+        strict_requirements: ~
+    form: ~
+    csrf_protection: ~
+    validation: { enable_annotations: true }
+    #serializer: { enable_annotations: true }
+    #templating:
+        #engines: ['twig']
+    default_locale: '%locale%'
+    trusted_hosts: ~
+    session:
+        # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
+        handler_id: session.handler.native_file
+        save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
+    fragments: ~
+    http_method_override: true
+    assets: ~
+    php_errors:
+        log: true

--- a/Configuration/config_dev.yml
+++ b/Configuration/config_dev.yml
@@ -1,9 +1,8 @@
 imports:
-  - { resource: "services.yml" }
+    - { resource: config.yml }
 
 framework:
-  profiler: { only_exceptions: false }
-  secret: d9c7e737bdb920e1d10df3588a3941782b905361
-  router:
-    resource: '%kernel.project_dir%/Configuration/routing_dev.yml'
-    strict_requirements: true
+    router:
+        resource: '%kernel.project_dir%/Configuration/routing_dev.yml'
+        strict_requirements: true
+    profiler: { only_exceptions: false }

--- a/Configuration/config_prod.yml
+++ b/Configuration/config_prod.yml
@@ -1,8 +1,2 @@
 imports:
-  - { resource: "services.yml" }
-
-framework:
-  secret: d9c7e737bdb920e1d10df3588a3941782b905361
-  router:
-    resource: '%kernel.project_dir%/Configuration/routing_prod.yml'
-    strict_requirements: true
+    - { resource: config.yml }

--- a/Configuration/config_test.yml
+++ b/Configuration/config_test.yml
@@ -1,13 +1,9 @@
 imports:
-  - { resource: "services.yml" }
+    - { resource: config_dev.yml }
 
 framework:
-  test: ~
-  session:
-    storage_id: session.storage.mock_file
-  profiler:
-    collect: false
-  secret: a95c530a7af5f492a74499e70578d150d9c7e737
-  router:
-    resource: '%kernel.project_dir%/Configuration/routing_test.yml'
-    strict_requirements: true
+    test: ~
+    session:
+        storage_id: session.storage.mock_file
+    profiler:
+        collect: false

--- a/Configuration/parameters.yml
+++ b/Configuration/parameters.yml
@@ -1,0 +1,3 @@
+# This file will later be moved out of the vendor package into the application folder.
+parameters:
+    secret: d9c7e737bdb920e1d10df3588a3941782b905361

--- a/Configuration/routing_dev.yml
+++ b/Configuration/routing_dev.yml
@@ -1,2 +1,2 @@
 _main:
-    resource: "routing.yml"
+    resource: routing.yml

--- a/Configuration/routing_prod.yml
+++ b/Configuration/routing_prod.yml
@@ -1,2 +1,0 @@
-_main:
-  resource: "routing.yml"

--- a/Configuration/routing_test.yml
+++ b/Configuration/routing_test.yml
@@ -1,2 +1,0 @@
-_main:
-  resource: "routing.yml"

--- a/Configuration/services.yml
+++ b/Configuration/services.yml
@@ -1,13 +1,23 @@
-services:
-  # default configuration for services in *this* file
-  _defaults:
-    # automatically injects dependencies in your services
-    autowire: true
-    # automatically registers your services as commands, event subscribers, etc.
-    autoconfigure: true
-    # this means you cannot fetch services directly from the container via $container->get()
-    # if you need to do this, you can override this setting on individual services
-    public: false
+# Learn more about services, parameters and containers at
+# https://symfony.com/doc/current/service_container.html
+parameters:
+    #parameter_name: value
 
-  PhpList\PhpList4\Routing\ExtraLoader:
-    tags: [routing.loader]
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        # automatically injects dependencies in your services
+        autowire: true
+        # automatically registers your services as commands, event subscribers, etc.
+        autoconfigure: true
+        # this means you cannot fetch services directly from the container via $container->get()
+        # if you need to do this, you can override this setting on individual services
+        public: false
+
+    # add more services, or override services that need manual wiring
+    # AppBundle\Service\ExampleService:
+    #     arguments:
+    #         $someArgument: 'some_value'
+
+    PhpList\PhpList4\Routing\ExtraLoader:
+        tags: [routing.loader]


### PR DESCRIPTION
Now the configuration is basically the same as the default configuration
of new Symfony projects (except for the parts which phpList is not using
yet).