### PR TITLE
[BUGFIX] Fix ApplicationKernel method signatures

### DIFF
--- a/Classes/Core/ApplicationKernel.php
+++ b/Classes/Core/ApplicationKernel.php
@@ -50,7 +50,7 @@ class ApplicationKernel extends Kernel
      *
      * @return string absolute path without the trailing slash
      */
-    public function getProjectDir(): string
+    public function getProjectDir()
     {
         return $this->getAndCreateApplicationStructure()->getCorePackageRoot();
     }
@@ -58,7 +58,7 @@ class ApplicationKernel extends Kernel
     /**
      * @return string
      */
-    public function getRootDir(): string
+    public function getRootDir()
     {
         return $this->getProjectDir();
     }


### PR DESCRIPTION
The return type hints for getProjectDir and getRootDir must not be present
so the method signatures do not clash with the methods in the parent class
(to avoid PHP errors).