### PR TITLE
[BUGFIX] Fix ApplicationKernel method signatures

### DIFF
--- a/Classes/Core/ApplicationKernel.php
+++ b/Classes/Core/ApplicationKernel.php
@@ -51,7 +51,7 @@ class ApplicationKernel extends Kernel
      *
      * @return string absolute path without the trailing slash
      */
-    public function getProjectDir(): string
+    public function getProjectDir()
     {
         return $this->getAndCreateApplicationStructure()->getCorePackageRoot();
     }
@@ -59,7 +59,7 @@ class ApplicationKernel extends Kernel
     /**
      * @return string
      */
-    public function getRootDir(): string
+    public function getRootDir()
     {
         return $this->getProjectDir();
     }
@@ -75,7 +75,7 @@ class ApplicationKernel extends Kernel
     /**
      * @return string
      */
-    public function getCacheDir(): string
+    public function getCacheDir()
     {
         return $this->getApplicationDir() . '/var/cache/' . $this->getEnvironment();
     }
@@ -83,7 +83,7 @@ class ApplicationKernel extends Kernel
     /**
      * @return string
      */
-    public function getLogDir(): string
+    public function getLogDir()
     {
         return $this->getApplicationDir() . '/var/logs';
     }


### PR DESCRIPTION
The return type hints for some public and private must not be present
so the method signatures do not clash with the generated cached subclasses
(which do not have the return type hints).