### PR TITLE
[BUGFIX] Create the bundle configuration in the correct location

### DIFF
--- a/Classes/Composer/ScriptHandler.php
+++ b/Classes/Composer/ScriptHandler.php
@@ -23,7 +23,7 @@ class ScriptHandler
     /**
      * @var string
      */
-    const BUNDLE_CONFIGURATION_FILE = 'Configuration/bundles.yml';
+    const BUNDLE_CONFIGURATION_FILE = '/Configuration/bundles.yml';
 
     /**
      * @return string absolute application root directory without the trailing slash
@@ -172,7 +172,7 @@ class ScriptHandler
         $bundleFinder = new ModuleBundleFinder();
         $bundleFinder->injectPackageRepository($packageRepository);
 
-        $configurationFilePath = __DIR__ . '/../../' . self::BUNDLE_CONFIGURATION_FILE;
+        $configurationFilePath = self::getApplicationRoot() . self::BUNDLE_CONFIGURATION_FILE;
         $fileHandle = fopen($configurationFilePath, 'w');
         fwrite($fileHandle, $bundleFinder->createBundleConfigurationYaml());
         fclose($fileHandle);


### PR DESCRIPTION
The configuration file needs to be located in the application root, not
in the project root, moving the configuration file out of the vendor/
folder for cases where phplist4-core is used as a library.

This is a follow-up fix to #158.