### PR TITLE
[BUGFIX] Always write the bundle configuration file in binary mode

### DIFF
--- a/Classes/Composer/ScriptHandler.php
+++ b/Classes/Composer/ScriptHandler.php
@@ -173,7 +173,7 @@ class ScriptHandler
         $bundleFinder->injectPackageRepository($packageRepository);
 
         $configurationFilePath = self::getApplicationRoot() . self::BUNDLE_CONFIGURATION_FILE;
-        $fileHandle = fopen($configurationFilePath, 'w');
+        $fileHandle = fopen($configurationFilePath, 'wb');
         fwrite($fileHandle, $bundleFinder->createBundleConfigurationYaml());
         fclose($fileHandle);
     }


### PR DESCRIPTION
Although not writing the file in binary mode does not create any errors,
it still is recommended to always write files in binary mode.