### PR TITLE
[TASK] Clean up the generated YAML bundle configuration file

### DIFF
--- a/Classes/Composer/ModuleBundleFinder.php
+++ b/Classes/Composer/ModuleBundleFinder.php
@@ -112,12 +112,16 @@ class ModuleBundleFinder
         $lf = chr(10);
         $yaml = self::YAML_COMMENT . $lf;
 
+        $bundleClassSets = $this->findBundleClasses();
+        if (count($bundleClassSets) === 0) {
+            return $yaml . '{  }';
+        }
+
         /** @var string[][] $bundleClasses */
-        foreach ($this->findBundleClasses() as $packageName => $bundleClasses) {
-            $yaml .= '"' . $packageName . '":' . $lf;
+        foreach ($bundleClassSets as $packageName => $bundleClasses) {
+            $yaml .= $packageName . ':' . $lf;
             foreach ($bundleClasses as $bundleClass) {
-                $escapedBundleClassName = str_replace('\\', '\\\\', $bundleClass);
-                $yaml .= '    - "' . $escapedBundleClassName . '"' . $lf;
+                $yaml .= '    - ' . $bundleClass . $lf;
             }
         }
 

--- a/Tests/Integration/Composer/ScriptsTest.php
+++ b/Tests/Integration/Composer/ScriptsTest.php
@@ -34,8 +34,8 @@ class ScriptsTest extends TestCase
     public function bundleClassNameDataProvider(): array
     {
         return [
-            'framework bundle' => ['Symfony\\\\Bundle\\\\FrameworkBundle\\\\FrameworkBundle'],
-            'application bundle' => ['PhpList\\\\PhpList4\\\\ApplicationBundle\\\\PhpListApplicationBundle'],
+            'framework bundle' => ['Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle'],
+            'application bundle' => ['PhpList\\PhpList4\\ApplicationBundle\\PhpListApplicationBundle'],
         ];
     }
 

--- a/Tests/Unit/Composer/ModuleBundleFinderTest.php
+++ b/Tests/Unit/Composer/ModuleBundleFinderTest.php
@@ -260,7 +260,7 @@ class ModuleBundleFinderTest extends TestCase
 
         $result = $this->subject->createBundleConfigurationYaml();
 
-        self::assertSame(self::YAML_COMMENT . chr(10), $result);
+        self::assertSame(self::YAML_COMMENT . chr(10) . '{  }', $result);
     }
 
     /**
@@ -280,8 +280,8 @@ class ModuleBundleFinderTest extends TestCase
                         ],
                     ],
                 ],
-                '"phplist/foo":' . $lf .
-                '    - "Symfony\\\\Bundle\\\\FrameworkBundle\\\\FrameworkBundle"' . $lf
+                'phplist/foo:' . $lf .
+                '    - Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle' . $lf
             ],
             'one module with two bundles' => [
                 [
@@ -294,9 +294,9 @@ class ModuleBundleFinderTest extends TestCase
                         ],
                     ],
                 ],
-                '"phplist/foo":' . $lf .
-                '    - "Symfony\\\\Bundle\\\\FrameworkBundle\\\\FrameworkBundle"' . $lf .
-                '    - "PhpList\\\\PhpList4\\\\ApplicationBundle\\\\PhpListApplicationBundle"' . $lf
+                'phplist/foo:' . $lf .
+                '    - Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle' . $lf .
+                '    - PhpList\\PhpList4\\ApplicationBundle\\PhpListApplicationBundle' . $lf
             ],
             'two module with one bundle each' => [
                 [
@@ -311,10 +311,10 @@ class ModuleBundleFinderTest extends TestCase
                         ],
                     ],
                 ],
-                '"phplist/foo":' . $lf .
-                '    - "Symfony\\\\Bundle\\\\FrameworkBundle\\\\FrameworkBundle"' . $lf .
-                '"phplist/bar":' . $lf .
-                '    - "PhpList\\\\PhpList4\\\\ApplicationBundle\\\\PhpListApplicationBundle"' . $lf
+                'phplist/foo:' . $lf .
+                '    - Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle' . $lf .
+                'phplist/bar:' . $lf .
+                '    - PhpList\\PhpList4\\ApplicationBundle\\PhpListApplicationBundle' . $lf
             ],
         ];
 


### PR DESCRIPTION
- don't quote strings that do not need to be quoted
- provide an empty hash if there is no data

This is a prerequisite to using the Symfony YAML component for
generating YAML files.