### PR TITLE
[CLEANUP] Remove the "lf" short variable name whitelisting

### DIFF
--- a/Configuration/PHPMD/rules.xml
+++ b/Configuration/PHPMD/rules.xml
@@ -42,7 +42,7 @@
     <!-- rules from the "naming" rule set -->
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>
-            <property name="exceptions" value="id,lf"/>
+            <property name="exceptions" value="id"/>
         </properties>
     </rule>
     <rule ref="rulesets/naming.xml/LongVariable">


### PR DESCRIPTION
We don't have the $lf variable anymore and hence don't need to whitelist
it in the PHPMD configuration anymore.