### PR TITLE
[CLEANUP] Rename Bootstrap::preventProductionEnvironment

### DIFF
--- a/Classes/Core/Bootstrap.php
+++ b/Classes/Core/Bootstrap.php
@@ -147,8 +147,7 @@ class Bootstrap
     }
 
     /**
-     * Checks that the application is not running on a production server, but on a local
-     * machine or via CLI.
+     * Checks that the application is running on a local testing machine or via CLI, not on a production server.
      *
      * If a production server is detected, a 403 header is sent and execution is stopped.
      *
@@ -157,7 +156,7 @@ class Bootstrap
      *
      * @return Bootstrap fluent interface
      */
-    public function preventProductionEnvironment(): Bootstrap
+    public function ensureDevelopmentOrTestingEnvironment(): Bootstrap
     {
         $usesProxy = isset($_SERVER['HTTP_CLIENT_IP']) || isset($_SERVER['HTTP_X_FORWARDED_FOR']);
         $isOnCli = PHP_SAPI === 'cli' || PHP_SAPI === 'cli-server';

--- a/Tests/Integration/Core/BootstrapTest.php
+++ b/Tests/Integration/Core/BootstrapTest.php
@@ -33,9 +33,9 @@ class BootstrapTest extends TestCase
     /**
      * @test
      */
-    public function preventProductionEnvironmentForTestingEnvironmentHasFluentInterface()
+    public function ensureDevelopmentOrTestingEnvironmentForTestingEnvironmentHasFluentInterface()
     {
-        self::assertSame($this->subject, $this->subject->preventProductionEnvironment());
+        self::assertSame($this->subject, $this->subject->ensureDevelopmentOrTestingEnvironment());
     }
 
     /**

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -7,7 +7,7 @@ use PhpList\PhpList4\Core\Environment;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 Bootstrap::getInstance()
-    ->preventProductionEnvironment()
+    ->ensureDevelopmentOrTestingEnvironment()
     ->setEnvironment(Environment::DEVELOPMENT)
     ->configure()
     ->dispatch();

--- a/web/app_test.php
+++ b/web/app_test.php
@@ -7,7 +7,7 @@ use PhpList\PhpList4\Core\Environment;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 Bootstrap::getInstance()
-    ->preventProductionEnvironment()
+    ->ensureDevelopmentOrTestingEnvironment()
     ->setEnvironment(Environment::TESTING)
     ->configure()
     ->dispatch();


### PR DESCRIPTION
The old name was awkward, hard to understand and kind of
reverse-logic.