### PR TITLE
[TASK] Enable the Symfony serializer

### DIFF
--- a/Configuration/config.yml
+++ b/Configuration/config.yml
@@ -17,7 +17,7 @@ framework:
     form: ~
     csrf_protection: ~
     validation: { enable_annotations: true }
-    #serializer: { enable_annotations: true }
+    serializer: { enable_annotations: true }
     #templating:
         #engines: ['twig']
     default_locale: '%locale%'


### PR DESCRIPTION
This is required for the switching the REST API to the
FOSRestBundle.