### PR TITLE
[FEATURE] Move the parameters.yml outside of the vendor/folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.webprj
 /composer.lock
 /Configuration/bundles.yml
+/Configuration/parameters.yml
 /Configuration/routing_modules.yml
 /nbproject
 /var/

--- a/Classes/Core/ApplicationKernel.php
+++ b/Classes/Core/ApplicationKernel.php
@@ -121,6 +121,7 @@ class ApplicationKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
+        $loader->load($this->getApplicationDir() . '/Configuration/parameters.yml');
         $loader->load($this->getRootDir() . '/Configuration/config_' . $this->getEnvironment() . '.yml');
     }
 

--- a/Configuration/config.yml
+++ b/Configuration/config.yml
@@ -1,5 +1,4 @@
 imports:
-    - { resource: parameters.yml }
     - { resource: services.yml }
 
 # Put parameters here that don't need to change on each machine where the app is deployed

--- a/Configuration/parameters.yml
+++ b/Configuration/parameters.yml
@@ -1,3 +1,0 @@
-# This file will later be moved out of the vendor package into the application folder.
-parameters:
-    secret: d9c7e737bdb920e1d10df3588a3941782b905361

--- a/Configuration/parameters_template.yml
+++ b/Configuration/parameters_template.yml
@@ -1,0 +1,2 @@
+parameters:
+    secret: %1$s

--- a/Tests/Integration/Composer/ScriptsTest.php
+++ b/Tests/Integration/Composer/ScriptsTest.php
@@ -91,4 +91,12 @@ class ScriptsTest extends TestCase
 
         self::assertContains($routeSearchString, $fileContents);
     }
+
+    /**
+     * @test
+     */
+    public function parametersConfigurationFileExists()
+    {
+        self::assertFileExists(dirname(__DIR__, 3) . '/Configuration/parameters.yml');
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "update-configuration": [
             "PhpList\\PhpList4\\Composer\\ScriptHandler::createBundleConfiguration",
             "PhpList\\PhpList4\\Composer\\ScriptHandler::createRoutesConfiguration",
+            "PhpList\\PhpList4\\Composer\\ScriptHandler::createParametersConfiguration",
             "PhpList\\PhpList4\\Composer\\ScriptHandler::clearAllCaches"
         ],
         "post-install-cmd": [


### PR DESCRIPTION
parameters.yml will contain installation-specific data and must not be
overwritten on a composer update. Hence, it needs to reside in the
Configuration/ folder of the application, not in the Configuration/
folder of the core package (will will get overwritten on an update).

Also automatically create the file on a composer install/update
(if the file does not exist yet).

This change is a prerequisite to switching to the Symfony Doctrine
integration.