### PR TITLE
[CLEANUP] Move some Bootstrap tests around

### DIFF
--- a/Tests/Integration/Core/BootstrapTest.php
+++ b/Tests/Integration/Core/BootstrapTest.php
@@ -6,7 +6,6 @@ namespace PhpList\PhpList4\Tests\Integration\Core;
 use PhpList\PhpList4\Core\Bootstrap;
 use PhpList\PhpList4\Core\Environment;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Testcase.
@@ -45,15 +44,5 @@ class BootstrapTest extends TestCase
     public function getApplicationRootReturnsCoreApplicationRoot()
     {
         self::assertSame(dirname(__DIR__, 3), $this->subject->getApplicationRoot());
-    }
-
-    /**
-     * @test
-     */
-    public function getContainerReturnsContainer()
-    {
-        $this->subject->configure();
-
-        self::assertInstanceOf(ContainerInterface::class, $this->subject->getContainer());
     }
 }

--- a/Tests/Unit/Core/BootstrapTest.php
+++ b/Tests/Unit/Core/BootstrapTest.php
@@ -8,6 +8,7 @@ use PhpList\PhpList4\Core\ApplicationKernel;
 use PhpList\PhpList4\Core\Bootstrap;
 use PhpList\PhpList4\Core\Environment;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Testcase.
@@ -126,26 +127,6 @@ class BootstrapTest extends TestCase
     /**
      * @test
      */
-    public function configureInitializesEntityManager()
-    {
-        $this->subject->configure();
-
-        self::assertInstanceOf(EntityManagerInterface::class, $this->subject->getEntityManager());
-    }
-
-    /**
-     * @test
-     */
-    public function getEntityManagerWithoutConfigureThrowsException()
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $this->subject->getEntityManager();
-    }
-
-    /**
-     * @test
-     */
     public function configureCreatesApplicationKernel()
     {
         $this->subject->configure();
@@ -171,5 +152,35 @@ class BootstrapTest extends TestCase
         $this->expectException(\RuntimeException::class);
 
         $this->subject->dispatch();
+    }
+
+    /**
+     * @test
+     */
+    public function getContainerReturnsContainer()
+    {
+        $this->subject->configure();
+
+        self::assertInstanceOf(ContainerInterface::class, $this->subject->getContainer());
+    }
+
+    /**
+     * @test
+     */
+    public function getEntityManagerWithoutConfigureThrowsException()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $this->subject->getEntityManager();
+    }
+
+    /**
+     * @test
+     */
+    public function getEntityManagerAfterConfigureReturnsEntityManager()
+    {
+        $this->subject->configure();
+
+        self::assertInstanceOf(EntityManagerInterface::class, $this->subject->getEntityManager());
     }
 }


### PR DESCRIPTION
- move a test that really is a unit test into the unit test case
- reorder some tests make the test case easier to understand

This cleanup will help make the Doctrine-Symfony integration PR
smaller.