### PR TITLE
[BUGFIX] Store the session data outside vendor/

### DIFF
--- a/Configuration/config.yml
+++ b/Configuration/config.yml
@@ -24,7 +24,7 @@ framework:
     session:
         # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         handler_id: session.handler.native_file
-        save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
+        save_path: '%kernel.application_dir%/var/sessions/%kernel.environment%'
     fragments: ~
     http_method_override: true
     assets: ~


### PR DESCRIPTION
The session data should be stored in var/sessions/ in the application
root, not in the phplist4-core directory within vendor/.

Fixes #195