### PR TITLE
[BUGFIX] Convert the repositories to public services

### DIFF
--- a/Configuration/config_test.yml
+++ b/Configuration/config_test.yml
@@ -7,11 +7,3 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         collect: false
-
-# These aliases allow retrieving non-public services via the container in the integration tests.
-# See https://symfony.com/doc/current/service_container/alias_private.html#aliasing for details.
-services:
-    test.AdministratorRepository:
-        alias: PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository
-    test.AdministratorTokenRepository:
-        alias: PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository

--- a/Configuration/services.yml
+++ b/Configuration/services.yml
@@ -20,16 +20,18 @@ services:
     PhpList\PhpList4\Routing\ExtraLoader:
         tags: [routing.loader]
 
-    PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository:
+    phplist.domain.repository.identity.AdministratorRepository:
         class: PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository
+        public: true
         factory: Doctrine\ORM\EntityManagerInterface:getRepository
         arguments:
             - PhpList\PhpList4\Domain\Model\Identity\Administrator
         calls:
             - [injectHashGenerator, ['@security.hash_generator']]
 
-    PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository:
+    phplist.domain.repository.identity.AdministratorTokenRepository:
         class: PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository
+        public: true
         factory: Doctrine\ORM\EntityManagerInterface:getRepository
         arguments:
             - PhpList\PhpList4\Domain\Model\Identity\AdministratorToken

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -31,7 +31,7 @@ class AdministratorRepositoryTest extends AbstractRepositoryTest
     {
         parent::setUp();
 
-        $this->subject = $this->container->get('test.AdministratorRepository');
+        $this->subject = $this->container->get('phplist.domain.repository.identity.AdministratorRepository');
     }
 
     /**

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -35,7 +35,7 @@ class AdministratorTokenRepositoryTest extends AbstractRepositoryTest
     {
         parent::setUp();
 
-        $this->subject = $this->container->get('test.AdministratorTokenRepository');
+        $this->subject = $this->container->get('phplist.domain.repository.identity.AdministratorTokenRepository');
     }
 
     /**


### PR DESCRIPTION
This is required so that the repositories can be injected into controllers.