### PR TITLE
[CLEANUP] Cleanup up the service configuration

### DIFF
--- a/Configuration/services.yml
+++ b/Configuration/services.yml
@@ -9,27 +9,30 @@ services:
         # if you need to do this, you can override this setting on individual services
         public: false
 
-    application.structure:
-        class: PhpList\PhpList4\Core\ApplicationStructure
+    PhpList\PhpList4\Core\ApplicationStructure:
         public: true
 
-    security.hash_generator:
-        class: PhpList\PhpList4\Security\HashGenerator
+    PhpList\PhpList4\Security\HashGenerator:
         public: true
 
     PhpList\PhpList4\Routing\ExtraLoader:
         tags: [routing.loader]
 
     PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository:
-        class: PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository
         factory: Doctrine\ORM\EntityManagerInterface:getRepository
         arguments:
             - PhpList\PhpList4\Domain\Model\Identity\Administrator
         calls:
-            - [injectHashGenerator, ['@security.hash_generator']]
+            - [injectHashGenerator, ['@PhpList\PhpList4\Security\HashGenerator']]
 
     PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository:
-        class: PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository
         factory: Doctrine\ORM\EntityManagerInterface:getRepository
         arguments:
             - PhpList\PhpList4\Domain\Model\Identity\AdministratorToken
+
+    # controllers are imported separately to make sure they're public
+    # and have a tag that allows actions to type-hint services
+    PhpList\PhpList4\EmptyStartPageBundle\Controller\:
+        resource: '../Classes/EmptyStartPageBundle/Controller'
+        public: true
+        tags: ['controller.service_arguments']

--- a/Tests/Integration/Core/ApplicationStructureTest.php
+++ b/Tests/Integration/Core/ApplicationStructureTest.php
@@ -49,7 +49,7 @@ class ApplicationStructureTest extends TestCase
      */
     public function subjectIsAvailableViaContainer()
     {
-        self::assertInstanceOf(ApplicationStructure::class, $this->container->get('application.structure'));
+        self::assertInstanceOf(ApplicationStructure::class, $this->container->get(ApplicationStructure::class));
     }
 
     /**
@@ -57,7 +57,7 @@ class ApplicationStructureTest extends TestCase
      */
     public function classIsRegisteredAsSingletonInContainer()
     {
-        $id = 'application.structure';
+        $id = ApplicationStructure::class;
 
         self::assertSame($this->container->get($id), $this->container->get($id));
     }

--- a/Tests/Integration/EmptyStartPageBundle/Controller/DefaultControllerTest.php
+++ b/Tests/Integration/EmptyStartPageBundle/Controller/DefaultControllerTest.php
@@ -5,6 +5,7 @@ namespace PhpList\PhpList4\Tests\Integration\EmptyStartPageBundle\Controller;
 
 use PhpList\PhpList4\Core\Bootstrap;
 use PhpList\PhpList4\Core\Environment;
+use PhpList\PhpList4\EmptyStartPageBundle\Controller\DefaultController;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -25,6 +26,14 @@ class DefaultControllerTest extends WebTestCase
         Bootstrap::getInstance()->setEnvironment(Environment::TESTING)->configure();
 
         $this->client = self::createClient(['environment' => Environment::TESTING]);
+    }
+
+    /**
+     * @test
+     */
+    public function controllerIsAvailableViaContainer()
+    {
+        self::assertInstanceOf(DefaultController::class, $this->client->getContainer()->get(DefaultController::class));
     }
 
     /**

--- a/Tests/Integration/Security/HashGeneratorTest.php
+++ b/Tests/Integration/Security/HashGeneratorTest.php
@@ -49,7 +49,7 @@ class HashGeneratorTest extends TestCase
      */
     public function subjectIsAvailableViaContainer()
     {
-        self::assertInstanceOf(HashGenerator::class, $this->container->get('security.hash_generator'));
+        self::assertInstanceOf(HashGenerator::class, $this->container->get(HashGenerator::class));
     }
 
     /**
@@ -57,7 +57,7 @@ class HashGeneratorTest extends TestCase
      */
     public function classIsRegisteredAsSingletonInContainer()
     {
-        $id = 'security.hash_generator';
+        $id = HashGenerator::class;
 
         self::assertSame($this->container->get($id), $this->container->get($id));
     }


### PR DESCRIPTION
- always use the class name as service name
- always register controllers as services and them for action injection

This makes the service configuration closer to the Symfony 3.3 defaults.