### PR TITLE
[BUGFIX] Convert the repositories to public services

### DIFF
--- a/Configuration/config_test.yml
+++ b/Configuration/config_test.yml
@@ -7,11 +7,3 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         collect: false
-
-# These aliases allow retrieving non-public services via the container in the integration tests.
-# See https://symfony.com/doc/current/service_container/alias_private.html#aliasing for details.
-services:
-    test.AdministratorRepository:
-        alias: PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository
-    test.AdministratorTokenRepository:
-        alias: PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository

--- a/Configuration/services.yml
+++ b/Configuration/services.yml
@@ -19,6 +19,7 @@ services:
         tags: [routing.loader]
 
     PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository:
+        public: true
         factory: Doctrine\ORM\EntityManagerInterface:getRepository
         arguments:
             - PhpList\PhpList4\Domain\Model\Identity\Administrator
@@ -26,6 +27,7 @@ services:
             - [injectHashGenerator, ['@PhpList\PhpList4\Security\HashGenerator']]
 
     PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository:
+        public: true
         factory: Doctrine\ORM\EntityManagerInterface:getRepository
         arguments:
             - PhpList\PhpList4\Domain\Model\Identity\AdministratorToken

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -31,15 +31,7 @@ class AdministratorRepositoryTest extends AbstractRepositoryTest
     {
         parent::setUp();
 
-        $this->subject = $this->container->get('test.AdministratorRepository');
-    }
-
-    /**
-     * @test
-     */
-    public function containerDeliversAdministratorRepository()
-    {
-        self::assertInstanceOf(AdministratorRepository::class, $this->subject);
+        $this->subject = $this->container->get(AdministratorRepository::class);
     }
 
     /**

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -35,15 +35,7 @@ class AdministratorTokenRepositoryTest extends AbstractRepositoryTest
     {
         parent::setUp();
 
-        $this->subject = $this->container->get('test.AdministratorTokenRepository');
-    }
-
-    /**
-     * @test
-     */
-    public function containerDeliversAdministratorTokenRepository()
-    {
-        self::assertInstanceOf(AdministratorTokenRepository::class, $this->subject);
+        $this->subject = $this->container->get(AdministratorTokenRepository::class);
     }
 
     /**


### PR DESCRIPTION
This is required so that the repositories can be injected into controllers.