### PR TITLE
[FEATURE] AbstractRepository.save

### DIFF
--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Domain\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use PhpList\PhpList4\Domain\Model\Interfaces\Identity;
+
+/**
+ * Base class for repositories.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+abstract class AbstractRepository extends EntityRepository
+{
+    /**
+     * Persists and $model and flushes the entity manager change list.
+     *
+     * This method allows controllers to not depend on the entity manager, but only on the repositories instead,
+     * following the Law of Demeter.
+     *
+     * @param Identity $model
+     *
+     * @return void
+     */
+    public function save(Identity $model)
+    {
+        $this->getEntityManager()->persist($model);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/Classes/Domain/Repository/Identity/AdministratorRepository.php
+++ b/Classes/Domain/Repository/Identity/AdministratorRepository.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace PhpList\PhpList4\Domain\Repository\Identity;
 
-use Doctrine\ORM\EntityRepository;
 use PhpList\PhpList4\Domain\Model\Identity\Administrator;
+use PhpList\PhpList4\Domain\Repository\AbstractRepository;
 use PhpList\PhpList4\Security\HashGenerator;
 
 /**
@@ -12,7 +12,7 @@ use PhpList\PhpList4\Security\HashGenerator;
  *
  * @author Oliver Klee <oliver@phplist.com>
  */
-class AdministratorRepository extends EntityRepository
+class AdministratorRepository extends AbstractRepository
 {
     /**
      * @var HashGenerator

--- a/Classes/Domain/Repository/Identity/AdministratorTokenRepository.php
+++ b/Classes/Domain/Repository/Identity/AdministratorTokenRepository.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 namespace PhpList\PhpList4\Domain\Repository\Identity;
 
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\ORM\EntityRepository;
 use PhpList\PhpList4\Domain\Model\Identity\AdministratorToken;
+use PhpList\PhpList4\Domain\Repository\AbstractRepository;
 
 /**
  * Repository for AdministratorToken models.
  *
  * @author Oliver Klee <oliver@phplist.com>
  */
-class AdministratorTokenRepository extends EntityRepository
+class AdministratorTokenRepository extends AbstractRepository
 {
     /**
      * Finds one unexpired token by the given key. Returns null if there is no match.

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -178,4 +178,15 @@ class AdministratorRepositoryTest extends AbstractRepositoryTest
 
         self::assertNull($result);
     }
+
+    /**
+     * @test
+     */
+    public function savePersistsAndFlushesModel()
+    {
+        $model = new Administrator();
+        $this->subject->save($model);
+
+        self::assertSame($model, $this->subject->find($model->getId()));
+    }
 }

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -6,6 +6,7 @@ namespace PhpList\PhpList4\Tests\Integration\Domain\Repository\Identity;
 use Doctrine\ORM\Proxy\Proxy;
 use PhpList\PhpList4\Domain\Model\Identity\Administrator;
 use PhpList\PhpList4\Domain\Model\Identity\AdministratorToken;
+use PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository;
 use PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository;
 use PhpList\PhpList4\Tests\Integration\Domain\Repository\AbstractRepositoryTest;
 
@@ -191,5 +192,24 @@ class AdministratorTokenRepositoryTest extends AbstractRepositoryTest
         $this->applyDatabaseChanges();
 
         self::assertSame(1, $this->subject->removeExpired());
+    }
+
+    /**
+     * @test
+     */
+    public function savePersistsAndFlushesModel()
+    {
+        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
+        $this->applyDatabaseChanges();
+
+        $administratorRepository = $this->container->get(AdministratorRepository::class);
+        /** @var Administrator $administrator */
+        $administrator = $administratorRepository->find(1);
+
+        $model = new AdministratorToken();
+        $model->setAdministrator($administrator);
+        $this->subject->save($model);
+
+        self::assertSame($model, $this->subject->find($model->getId()));
     }
 }


### PR DESCRIPTION
This method allows controllers to not depend on the entity manager,
but only on the repositories instead, following the Law of Demeter.