### PR TITLE
[BUGFIX] Load the module-provided config from application root

### DIFF
--- a/Classes/Core/ApplicationKernel.php
+++ b/Classes/Core/ApplicationKernel.php
@@ -123,7 +123,7 @@ class ApplicationKernel extends Kernel
     {
         $loader->load($this->getApplicationDir() . '/Configuration/parameters.yml');
         $loader->load($this->getRootDir() . '/Configuration/config_' . $this->getEnvironment() . '.yml');
-        $loader->load($this->getRootDir() . '/Configuration/config_modules.yml');
+        $loader->load($this->getApplicationDir() . '/Configuration/config_modules.yml');
     }
 
     /**


### PR DESCRIPTION
This will make sure that the configuration file works when the
core package is used as a library.