### PR TITLE
[CLEANUP] Clean up the service definitions

### DIFF
--- a/Classes/Domain/Repository/Identity/AdministratorRepository.php
+++ b/Classes/Domain/Repository/Identity/AdministratorRepository.php
@@ -21,6 +21,7 @@ class AdministratorRepository extends AbstractRepository
 
     /**
      * @param HashGenerator $hashGenerator
+     * @required
      *
      * @return void
      */

--- a/Configuration/config.yml
+++ b/Configuration/config.yml
@@ -1,5 +1,6 @@
 imports:
     - { resource: services.yml }
+    - { resource: repositories.yml }
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration

--- a/Configuration/repositories.yml
+++ b/Configuration/repositories.yml
@@ -1,0 +1,10 @@
+services:
+    PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository:
+        parent: PhpList\PhpList4\Domain\Repository
+        arguments:
+            - PhpList\PhpList4\Domain\Model\Identity\Administrator
+
+    PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository:
+        parent: PhpList\PhpList4\Domain\Repository
+        arguments:
+            - PhpList\PhpList4\Domain\Model\Identity\AdministratorToken

--- a/Configuration/services.yml
+++ b/Configuration/services.yml
@@ -18,23 +18,16 @@ services:
     PhpList\PhpList4\Routing\ExtraLoader:
         tags: [routing.loader]
 
-    PhpList\PhpList4\Domain\Repository\Identity\AdministratorRepository:
+    PhpList\PhpList4\Domain\Repository:
+        abstract: true
+        autowire: true
+        autoconfigure: false
         public: true
         factory: Doctrine\ORM\EntityManagerInterface:getRepository
-        arguments:
-            - PhpList\PhpList4\Domain\Model\Identity\Administrator
-        calls:
-            - [injectHashGenerator, ['@PhpList\PhpList4\Security\HashGenerator']]
-
-    PhpList\PhpList4\Domain\Repository\Identity\AdministratorTokenRepository:
-        public: true
-        factory: Doctrine\ORM\EntityManagerInterface:getRepository
-        arguments:
-            - PhpList\PhpList4\Domain\Model\Identity\AdministratorToken
 
     # controllers are imported separately to make sure they're public
     # and have a tag that allows actions to type-hint services
     PhpList\PhpList4\EmptyStartPageBundle\Controller\:
         resource: '../Classes/EmptyStartPageBundle/Controller'
         public: true
-        tags: ['controller.service_arguments']
+        tags: [controller.service_arguments]


### PR DESCRIPTION
- mark the setter injection of the HashGenerator in the AdministratorRepository
  as @required, which allows us to remove the DI configuration from services.yml
- use an abstract service for all repositories and move the definitions of the
  repository services into a separate file (which is necessary for them to have
  the abstract service as parent)
- drop optional quotes from the tags of the controller so the tag definitions
  are consistent