### PR TITLE
[CLEANUP] Add the @Column annotation to the Identity trait

### DIFF
--- a/Classes/Domain/Model/Traits/IdentityTrait.php
+++ b/Classes/Domain/Model/Traits/IdentityTrait.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace PhpList\PhpList4\Domain\Model\Traits;
 
+use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 
@@ -17,7 +18,8 @@ trait IdentityTrait
 {
     /**
      * @var int
-     * @Id @Column(type="integer")
+     * @Id
+     * @Column(type="integer")
      * @GeneratedValue
      */
     private $id = 0;


### PR DESCRIPTION
This will allow having models that use the Identity trait, but do not use
any other @Column annotations themselves.