### PR TITLE
[CLEANUP] Traits for creation and modification dates

### DIFF
--- a/Classes/Domain/Model/Identity/Administrator.php
+++ b/Classes/Domain/Model/Identity/Administrator.php
@@ -6,11 +6,13 @@ namespace PhpList\PhpList4\Domain\Model\Identity;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\HasLifecycleCallbacks;
-use Doctrine\ORM\Mapping\PrePersist;
-use Doctrine\ORM\Mapping\PreUpdate;
 use Doctrine\ORM\Mapping\Table;
+use PhpList\PhpList4\Domain\Model\Interfaces\CreationDate;
 use PhpList\PhpList4\Domain\Model\Interfaces\Identity;
+use PhpList\PhpList4\Domain\Model\Interfaces\ModificationDate;
+use PhpList\PhpList4\Domain\Model\Traits\CreationDateTrait;
 use PhpList\PhpList4\Domain\Model\Traits\IdentityTrait;
+use PhpList\PhpList4\Domain\Model\Traits\ModificationDateTrait;
 
 /**
  * This class represents an administrator who can log to the system, is allowed to administer
@@ -22,9 +24,11 @@ use PhpList\PhpList4\Domain\Model\Traits\IdentityTrait;
  *
  * @author Oliver Klee <oliver@phplist.com>
  */
-class Administrator implements Identity
+class Administrator implements Identity, CreationDate, ModificationDate
 {
     use IdentityTrait;
+    use CreationDateTrait;
+    use ModificationDateTrait;
 
     /**
      * @var string
@@ -42,13 +46,13 @@ class Administrator implements Identity
      * @var \DateTime|null
      * @Column(type="datetime", nullable=true, name="created")
      */
-    private $creationDate = null;
+    protected $creationDate = null;
 
     /**
      * @var \DateTime|null
      * @Column(type="datetime", nullable=true, name="modified")
      */
-    private $modificationDate = null;
+    protected $modificationDate = null;
 
     /**
      * @var string
@@ -102,67 +106,6 @@ class Administrator implements Identity
     public function setEmailAddress(string $emailAddress)
     {
         $this->emailAddress = $emailAddress;
-    }
-
-    /**
-     * @return \DateTime|null
-     */
-    public function getCreationDate()
-    {
-        return $this->creationDate;
-    }
-
-    /**
-     * @param \DateTime $creationDate
-     *
-     * @return void
-     */
-    private function setCreationDate(\DateTime $creationDate)
-    {
-        $this->creationDate = $creationDate;
-    }
-
-    /**
-     * Updates the creation date to now.
-     *
-     * @PrePersist
-     *
-     * @return void
-     */
-    public function updateCreationDate()
-    {
-        $this->setCreationDate(new \DateTime());
-    }
-
-    /**
-     * @return \DateTime|null
-     */
-    public function getModificationDate()
-    {
-        return $this->modificationDate;
-    }
-
-    /**
-     * @param \DateTime $modificationDate
-     *
-     * @return void
-     */
-    private function setModificationDate(\DateTime $modificationDate)
-    {
-        $this->modificationDate = $modificationDate;
-    }
-
-    /**
-     * Updates the modification date to now.
-     *
-     * @PrePersist
-     * @PreUpdate
-     *
-     * @return void
-     */
-    public function updateModificationDate()
-    {
-        $this->setModificationDate(new \DateTime());
     }
 
     /**

--- a/Classes/Domain/Model/Interfaces/CreationDate.php
+++ b/Classes/Domain/Model/Interfaces/CreationDate.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Domain\Model\Interfaces;
+
+use Doctrine\ORM\Mapping\PrePersist;
+
+/**
+ * This interface communicates that a domain model has a creation date.
+ *
+ * The CreationDateTrait is the default implementation.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+interface CreationDate
+{
+    /**
+     * @return \DateTime|null
+     */
+    public function getCreationDate();
+
+    /**
+     * Updates the creation date to now.
+     *
+     * @PrePersist
+     *
+     * @return void
+     */
+    public function updateCreationDate();
+}

--- a/Classes/Domain/Model/Interfaces/ModificationDate.php
+++ b/Classes/Domain/Model/Interfaces/ModificationDate.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Domain\Model\Interfaces;
+
+use Doctrine\ORM\Mapping\PrePersist;
+use Doctrine\ORM\Mapping\PreUpdate;
+
+/**
+ * This interface communicates that a domain model has a modification date.
+ *
+ * The ModificationDateTrait is the default implementation.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+interface ModificationDate
+{
+    /**
+     * @return \DateTime|null
+     */
+    public function getModificationDate();
+
+    /**
+     * Updates the modification date to now.
+     *
+     * @PrePersist
+     * @PreUpdate
+     *
+     * @return void
+     */
+    public function updateModificationDate();
+}

--- a/Classes/Domain/Model/Traits/CreationDateTrait.php
+++ b/Classes/Domain/Model/Traits/CreationDateTrait.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Domain\Model\Traits;
+
+use Doctrine\ORM\Mapping\PrePersist;
+
+/**
+ * This trait provides an automatic creation date for models.
+ *
+ * This is the default implementation of the CreationDate interface.
+ *
+ * Please note that this trait requires the model to have the "HasLifecycleCallbacks" annotation in the class doc block,
+ * and also to have a $creationDate property with the correct column name mapping.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+trait CreationDateTrait
+{
+    /**
+     * @return \DateTime|null
+     */
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+
+    /**
+     * @param \DateTime $creationDate
+     *
+     * @return void
+     */
+    private function setCreationDate(\DateTime $creationDate)
+    {
+        $this->creationDate = $creationDate;
+    }
+
+    /**
+     * Updates the creation date to now.
+     *
+     * @PrePersist
+     *
+     * @return void
+     */
+    public function updateCreationDate()
+    {
+        $this->setCreationDate(new \DateTime());
+    }
+}

--- a/Classes/Domain/Model/Traits/IdentityTrait.php
+++ b/Classes/Domain/Model/Traits/IdentityTrait.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 
 /**
- * This class provides an ID property to domain models.
+ * This trait provides an ID property to domain models.
  *
  * This is the default implementation of the Identity interface.
  *

--- a/Classes/Domain/Model/Traits/ModificationDateTrait.php
+++ b/Classes/Domain/Model/Traits/ModificationDateTrait.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\PhpList4\Domain\Model\Traits;
+
+use Doctrine\ORM\Mapping\PrePersist;
+use Doctrine\ORM\Mapping\PreUpdate;
+
+/**
+ * This trait provides an automatic modification date for models.
+ *
+ * This is the default implementation of the ModificationDate interface.
+ *
+ * Please note that this trait requires the model to have the "HasLifecycleCallbacks" annotation in the class doc block,
+ * and also to have a $modificationDate property with the correct column name mapping.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+trait ModificationDateTrait
+{
+    /**
+     * @return \DateTime|null
+     */
+    public function getModificationDate()
+    {
+        return $this->modificationDate;
+    }
+
+    /**
+     * @param \DateTime $modificationDate
+     *
+     * @return void
+     */
+    private function setModificationDate(\DateTime $modificationDate)
+    {
+        $this->modificationDate = $modificationDate;
+    }
+
+    /**
+     * Updates the modification date to now.
+     *
+     * @PrePersist
+     * @PreUpdate
+     *
+     * @return void
+     */
+    public function updateModificationDate()
+    {
+        $this->setModificationDate(new \DateTime());
+    }
+}


### PR DESCRIPTION
Also make the affected properties in the Administrator model
protected instead of private so that the static code analysis
will not mark them as unused.