### PR TITLE
[TASK] Switch from the Symfony serializer to JMS serializer

### DIFF
--- a/Configuration/config.yml
+++ b/Configuration/config.yml
@@ -17,7 +17,7 @@ framework:
     form: ~
     csrf_protection: ~
     validation: { enable_annotations: true }
-    serializer: { enable_annotations: true }
+    #serializer: { enable_annotations: true }
     #templating:
         #engines: ['twig']
     default_locale: '%locale%'

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/dependency-injection": "^3.0.0",
         "symfony/config": "^3.0.0",
         "symfony/yaml": "^3.0.0",
+        "jms/serializer-bundle": "^2.2",
         "sensio/framework-extra-bundle": "^3.0.26",
         "sensio/distribution-bundle": "^5.0.0"
     },
@@ -97,6 +98,7 @@
             "bundles": [
                 "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle",
                 "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle",
+                "JMS\\SerializerBundle\\JMSSerializerBundle",
                 "Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle",
                 "PhpList\\PhpList4\\EmptyStartPageBundle\\PhpListEmptyStartPageBundle"
             ],


### PR DESCRIPTION
This allows us to easily convert entities to JSON in responses,
e.g., in the REST API.