### PR TITLE
[TASK] Whitelist the FOSRestBundle view class for static access

### DIFF
--- a/Configuration/PHPMD/rules.xml
+++ b/Configuration/PHPMD/rules.xml
@@ -9,7 +9,7 @@
     <rule ref="rulesets/cleancode.xml/StaticAccess">
         <properties>
             <property name="exceptions"
-                      value="\Doctrine\ORM\EntityManager,\Doctrine\ORM\Tools\Setup,\Symfony\Component\Debug\Debug,PhpList\PhpList4\Core\Environment,Symfony\Component\Yaml\Yaml"/>
+                      value="\Doctrine\ORM\EntityManager,\Doctrine\ORM\Tools\Setup,\Symfony\Component\Debug\Debug,PhpList\PhpList4\Core\Environment,Symfony\Component\Yaml\Yaml,\FOS\RestBundle\View\View"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
The class needs to be accessed statically, and we need PHPMD to not
complain about this.