### PR TITLE
[CLEANUP] Fix the names of repository integration tests

### DIFF
--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -13,7 +13,7 @@ use PhpList\PhpList4\Tests\Support\Traits\SimilarDatesAssertionTrait;
  *
  * @author Oliver Klee <oliver@phplist.com>
  */
-class AdministratorDatabaseTest extends AbstractDatabaseTest
+class AdministratorRepositoryTest extends AbstractDatabaseTest
 {
     use SimilarDatesAssertionTrait;
 

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -16,7 +16,7 @@ use PhpList\PhpList4\Tests\Support\Traits\SimilarDatesAssertionTrait;
  *
  * @author Oliver Klee <oliver@phplist.com>
  */
-class AdministratorTokenDatabaseTest extends AbstractDatabaseTest
+class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
 {
     use SimilarDatesAssertionTrait;
 

--- a/Tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
@@ -16,7 +16,7 @@ use PhpList\PhpList4\Tests\Support\Traits\SimilarDatesAssertionTrait;
  *
  * @author Oliver Klee <oliver@phplist.com>
  */
-class SubscriberListDatabaseTest extends AbstractDatabaseTest
+class SubscriberListRepositoryTest extends AbstractDatabaseTest
 {
     use SimilarDatesAssertionTrait;
 

--- a/Tests/Integration/Domain/Repository/Subscription/SubscriberRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Subscription/SubscriberRepositoryTest.php
@@ -14,7 +14,7 @@ use PhpList\PhpList4\Tests\Support\Traits\SimilarDatesAssertionTrait;
  *
  * @author Oliver Klee <oliver@phplist.com>
  */
-class SubscriberDatabaseTest extends AbstractDatabaseTest
+class SubscriberRepositoryTest extends AbstractDatabaseTest
 {
     use SimilarDatesAssertionTrait;
 


### PR DESCRIPTION
The previous semi-automatic renaming was too eager and had renamed all
*RepositoryTest to *DatabaseTest. This change now is reverted.