### PR TITLE
[TASK] Monolog configuration

### DIFF
--- a/Configuration/config_dev.yml
+++ b/Configuration/config_dev.yml
@@ -6,3 +6,29 @@ framework:
         resource: '%kernel.project_dir%/Configuration/routing_dev.yml'
         strict_requirements: true
     profiler: { only_exceptions: false }
+
+monolog:
+    handlers:
+        main:
+            type: stream
+            path: '%kernel.logs_dir%/%kernel.environment%.log'
+            level: debug
+            channels: ['!event']
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ['!event', '!doctrine', '!console']
+        # To follow logs in real time, execute the following command:
+        # `bin/console server:log -vv`
+        server_log:
+            type: server_log
+            process_psr_3_messages: false
+            host: 127.0.0.1:9911
+        # uncomment to get logging in your browser
+        # you may have to allow bigger header sizes in your Web server configuration
+        #firephp:
+        #    type: firephp
+        #    level: info
+        #chromephp:
+        #    type: chromephp
+        #    level: info

--- a/Configuration/config_prod.yml
+++ b/Configuration/config_prod.yml
@@ -1,2 +1,16 @@
 imports:
     - { resource: config.yml }
+
+monolog:
+    handlers:
+        main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+        nested:
+            type: stream
+            path: '%kernel.logs_dir%/%kernel.environment%.log'
+            level: debug
+        console:
+            type: console
+            process_psr_3_messages: false

--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
             "bundles": [
                 "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle",
                 "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle",
+                "Symfony\\Bundle\\MonologBundle\\MonologBundle",
                 "JMS\\SerializerBundle\\JMSSerializerBundle",
                 "Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle",
                 "PhpList\\PhpList4\\EmptyStartPageBundle\\PhpListEmptyStartPageBundle"


### PR DESCRIPTION
This change gets Monolog to log to a file when running the integration
tests instead of spamming the console with the log messages, making
problems in the tests and error messages easier to spot.

This change does not add any additional logging, though.