### PR TITLE
[BUGFIX] Always use UTC as token creation date time zone

### DIFF
--- a/Classes/Domain/Model/Identity/AdministratorToken.php
+++ b/Classes/Domain/Model/Identity/AdministratorToken.php
@@ -80,6 +80,7 @@ class AdministratorToken implements Identity, CreationDate
 
         $date = new \DateTime();
         $date->setTimestamp($this->creationDate);
+        $date->setTimezone(new \DateTimeZone('UTC'));
         return $date;
     }
 

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -51,7 +51,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
         $this->applyDatabaseChanges();
 
         $id = 1;
-        $creationDate = new \DateTime('2017-12-06 17:41:40');
+        $creationDate = new \DateTime('2017-12-06 17:41:40+0000');
         $expiry = new \DateTime('2017-06-22 16:43:29');
         $key = 'cfdf64eecbbf336628b0f3071adba762';
 


### PR DESCRIPTION
The creation date is saved in the database as a UNIX timestamp
and thus does not contain a time zone. This causes the timestamp
to result in different dates depending on the time zone set in
the PHP configuration, leading to test failures on some systems.

Now the timestamp will always be interpreted to be in the UTC
timezone.