### PR TITLE
[TASK] Test with both latest and oldest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
-matrix:
-  include:
-  - php: 7.0
-  - php: 7.1
-  - php: 7.2
+php:
+- 7.0
+- 7.1
+- 7.2
 
 services:
 - mysql
@@ -12,9 +11,10 @@ services:
 env:
   global:
   - secure: GRmIZt08nxg5r3uREPfW2Gz49LIkFVmU/kzSzJ78VISmjuWMUdiZ9GJFmzzvKBxQ0tzUlpvibBu1dvSqOAA4HZ72+p2PvTvezgL8S6dyaJ7bHRlyQlE1SDkK/tctFrIjGdXLAP7vNwqC7ZXtX7iH9Fk3znxy9BnLp4xGZDW54YU=
-  - PHPLIST_DATABASE_NAME=phplist
-  - PHPLIST_DATABASE_USER=travis
-  - PHPLIST_DATABASE_PASSWORD=''
+  - PHPLIST_DATABASE_NAME=phplist PHPLIST_DATABASE_USER=travis PHPLIST_DATABASE_PASSWORD=''
+  matrix:
+  - DEPENDENCIES=latest
+  - DEPENDENCIES=oldest
 
 notifications:
   slack:
@@ -40,7 +40,16 @@ before_install:
   mysql ${PHPLIST_DATABASE_NAME} < Database/Schema.sql;
 
 install:
-- composer install
+- >
+  echo;
+  if [ "$DEPENDENCIES" = "latest" ]; then
+    echo "Installing the latest dependencies";
+    composer update --with-dependencies --prefer-stable --prefer-dist
+  else
+    echo "Installing the lowest dependencies";
+    composer update --with-dependencies --prefer-stable --prefer-dist --prefer-lowest
+  fi;
+  composer show;
 
 script:
 - >

--- a/composer.json
+++ b/composer.json
@@ -28,22 +28,25 @@
 
         "roave/security-advisories": "dev-master",
 
-        "doctrine/orm": "^2.5.6",
-        "doctrine/doctrine-bundle": "^1.6.0",
-        "symfony/symfony": "^3.3.2",
+        "doctrine/orm": "^2.5.0",
+        "doctrine/common": "^2.6.0",
+        "doctrine/doctrine-bundle": "^1.8.0",
+        "symfony/symfony": "^3.3.0",
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/dependency-injection": "^3.0.0",
         "symfony/config": "^3.0.0",
         "symfony/yaml": "^3.0.0",
         "jms/serializer-bundle": "^2.2",
-        "sensio/framework-extra-bundle": "^3.0.26",
-        "sensio/distribution-bundle": "^5.0.0"
+        "sensio/framework-extra-bundle": "^3.0.0",
+        "sensio/distribution-bundle": "^5.0.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2.2",
         "phpunit/dbunit": "^3.0.0",
-        "squizlabs/php_codesniffer": "^3.0.1",
+        "squizlabs/php_codesniffer": "^3.0.0",
         "phpstan/phpstan": "^0.7.0",
+        "nette/caching": "^2.5.0 || ^3.0.0",
+        "nikic/php-parser": "^3.0.0",
         "phpmd/phpmd": "^2.6.0",
         "composer/composer": "^1.5.0"
     },


### PR DESCRIPTION
This ensures that our dependency versions given in the composer.json always
provide a working set of packages.

Also make the dependencies more lenient and provide explicit minimal versions
for some indirect dependencies.