### PR TITLE
[TASK] Update license info in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "manager"
     ],
     "homepage": "https://www.phplist.com/",
-    "license": "AGPL-3.0",
+    "license": "AGPL-3.0-or-later",
     "authors": [
         {
             "name": "Oliver Klee",


### PR DESCRIPTION
"AGPL-3.0" is deprecated. Updating this avoids
warnings with Composer 1.6.