### PR TITLE
[BUGFIX] Adapt the system tests to possible HTTP errors

### DIFF
--- a/Tests/System/ApplicationBundle/PhpListApplicationBundleTest.php
+++ b/Tests/System/ApplicationBundle/PhpListApplicationBundleTest.php
@@ -23,7 +23,7 @@ class PhpListApplicationBundleTest extends TestCase
 
     protected function setUp()
     {
-        $this->httpClient = new Client();
+        $this->httpClient = new Client(['http_errors' => false]);
     }
 
     protected function tearDown()


### PR DESCRIPTION
Now, an error HTTP status code can also be checked for in the system
tests (instead of throwing an exception).

This currently is not needed yet, but should be consistent to the system
tests of the rest-api package (where this is needed).