### PR TITLE
[BUGFIX] Load database fixture in AdministratorRepositoryTest

### DIFF
--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -139,6 +139,9 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function findOneByLoginCredentialsForMatchingCredentialsReturnsModel()
     {
+        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->applyDatabaseChanges();
+
         $id = 1;
         $loginName = 'john.doe';
         $password = 'Bazinga!';


### PR DESCRIPTION
The test findOneByLoginCredentialsForMatchingCredentialsReturnsModel
was not loading the database fixtures, causing the test to fail when
executed stand-alone (or when executed together with other tests when
the database tables got properly truncated on tearDown).