### PR TITLE
[TASK] Use static:: instead of self::

### DIFF
--- a/Classes/Composer/ModuleFinder.php
+++ b/Classes/Composer/ModuleFinder.php
@@ -126,7 +126,7 @@ class ModuleFinder
      */
     public function createBundleConfigurationYaml(): string
     {
-        return self::YAML_COMMENT . "\n" . Yaml::dump($this->findBundleClasses());
+        return static::YAML_COMMENT . "\n" . Yaml::dump($this->findBundleClasses());
     }
 
     /**
@@ -209,7 +209,7 @@ class ModuleFinder
      */
     public function createRouteConfigurationYaml(): string
     {
-        return self::YAML_COMMENT . "\n" . Yaml::dump($this->findRoutes());
+        return static::YAML_COMMENT . "\n" . Yaml::dump($this->findRoutes());
     }
 
     /**
@@ -274,6 +274,6 @@ class ModuleFinder
      */
     public function createGeneralConfigurationYaml(): string
     {
-        return self::YAML_COMMENT . "\n" . Yaml::dump($this->findGeneralConfiguration());
+        return static::YAML_COMMENT . "\n" . Yaml::dump($this->findGeneralConfiguration());
     }
 }

--- a/Classes/Composer/PackageRepository.php
+++ b/Classes/Composer/PackageRepository.php
@@ -84,7 +84,7 @@ class PackageRepository
         return array_filter(
             $this->findAll(),
             function (PackageInterface $package) {
-                return $package->getType() === self::PHPLIST_MODULE_TYPE;
+                return $package->getType() === static::PHPLIST_MODULE_TYPE;
             }
         );
     }

--- a/Classes/Composer/ScriptHandler.php
+++ b/Classes/Composer/ScriptHandler.php
@@ -62,7 +62,7 @@ class ScriptHandler extends SensioScriptHandler
      */
     private static function getCoreDirectory(): string
     {
-        return self::getApplicationRoot() . '/vendor/' . self::CORE_PACKAGE_NAME;
+        return static::getApplicationRoot() . '/vendor/' . static::CORE_PACKAGE_NAME;
     }
 
     /**
@@ -78,8 +78,8 @@ class ScriptHandler extends SensioScriptHandler
      */
     public static function createBinaries(Event $event)
     {
-        self::preventScriptFromCorePackage($event);
-        self::mirrorDirectoryFromCore('bin');
+        static::preventScriptFromCorePackage($event);
+        static::mirrorDirectoryFromCore('bin');
     }
 
     /**
@@ -95,8 +95,8 @@ class ScriptHandler extends SensioScriptHandler
      */
     public static function createPublicWebDirectory(Event $event)
     {
-        self::preventScriptFromCorePackage($event);
-        self::mirrorDirectoryFromCore('web');
+        static::preventScriptFromCorePackage($event);
+        static::mirrorDirectoryFromCore('web');
     }
 
     /**
@@ -110,7 +110,7 @@ class ScriptHandler extends SensioScriptHandler
     {
         $composer = $event->getComposer();
         $packageName = $composer->getPackage()->getName();
-        if ($packageName === self::CORE_PACKAGE_NAME) {
+        if ($packageName === static::CORE_PACKAGE_NAME) {
             throw new \DomainException(
                 'This Composer script must not be called for the phplist4-core package itself.',
                 1501240572934
@@ -135,8 +135,8 @@ class ScriptHandler extends SensioScriptHandler
 
         $fileSystem = new Filesystem();
         $fileSystem->mirror(
-            self::getCoreDirectory() . $directoryWithSlashes,
-            self::getApplicationRoot() . $directoryWithSlashes,
+            static::getCoreDirectory() . $directoryWithSlashes,
+            static::getApplicationRoot() . $directoryWithSlashes,
             null,
             ['override' => true, 'delete' => false]
         );
@@ -155,7 +155,7 @@ class ScriptHandler extends SensioScriptHandler
         $packageRepository->injectComposer($event->getComposer());
 
         $modules = $packageRepository->findModules();
-        $maximumPackageNameLength = self::calculateMaximumPackageNameLength($modules);
+        $maximumPackageNameLength = static::calculateMaximumPackageNameLength($modules);
 
         foreach ($modules as $module) {
             $paddedName = str_pad($module->getName(), $maximumPackageNameLength + 1);
@@ -188,9 +188,9 @@ class ScriptHandler extends SensioScriptHandler
      */
     public static function createBundleConfiguration(Event $event)
     {
-        self::createAndWriteFile(
-            self::getApplicationRoot() . self::BUNDLE_CONFIGURATION_FILE,
-            self::createAndInitializeModuleFinder($event)->createBundleConfigurationYaml()
+        static::createAndWriteFile(
+            static::getApplicationRoot() . static::BUNDLE_CONFIGURATION_FILE,
+            static::createAndInitializeModuleFinder($event)->createBundleConfigurationYaml()
         );
     }
 
@@ -223,9 +223,9 @@ class ScriptHandler extends SensioScriptHandler
      */
     public static function createRoutesConfiguration(Event $event)
     {
-        self::createAndWriteFile(
-            self::getApplicationRoot() . self::ROUTES_CONFIGURATION_FILE,
-            self::createAndInitializeModuleFinder($event)->createRouteConfigurationYaml()
+        static::createAndWriteFile(
+            static::getApplicationRoot() . static::ROUTES_CONFIGURATION_FILE,
+            static::createAndInitializeModuleFinder($event)->createRouteConfigurationYaml()
         );
     }
 
@@ -253,7 +253,7 @@ class ScriptHandler extends SensioScriptHandler
     public static function clearAllCaches()
     {
         $fileSystem = new Filesystem();
-        $fileSystem->remove(self::getApplicationRoot() . '/var/cache');
+        $fileSystem->remove(static::getApplicationRoot() . '/var/cache');
     }
 
     /**
@@ -265,12 +265,12 @@ class ScriptHandler extends SensioScriptHandler
      */
     public static function warmProductionCache(Event $event)
     {
-        $consoleDir = self::getConsoleDir($event, 'warm the cache');
+        $consoleDir = static::getConsoleDir($event, 'warm the cache');
         if ($consoleDir === null) {
             return;
         }
 
-        self::executeCommand($event, $consoleDir, 'cache:warm -e prod');
+        static::executeCommand($event, $consoleDir, 'cache:warm -e prod');
     }
 
     /**
@@ -280,18 +280,18 @@ class ScriptHandler extends SensioScriptHandler
      */
     public static function createParametersConfiguration()
     {
-        $configurationFilePath = self::getApplicationRoot() . self::PARAMETERS_CONFIGURATION_FILE;
+        $configurationFilePath = static::getApplicationRoot() . static::PARAMETERS_CONFIGURATION_FILE;
         if (file_exists($configurationFilePath)) {
             return;
         }
 
-        $templateFilePath = __DIR__ . '/../..' . self::PARAMETERS_TEMPLATE_FILE;
+        $templateFilePath = __DIR__ . '/../..' . static::PARAMETERS_TEMPLATE_FILE;
         $template = file_get_contents($templateFilePath);
 
         $secret = bin2hex(random_bytes(20));
         $configuration = sprintf($template, $secret);
 
-        self::createAndWriteFile($configurationFilePath, $configuration);
+        static::createAndWriteFile($configurationFilePath, $configuration);
     }
 
     /**
@@ -303,9 +303,9 @@ class ScriptHandler extends SensioScriptHandler
      */
     public static function createGeneralConfiguration(Event $event)
     {
-        self::createAndWriteFile(
-            self::getApplicationRoot() . self::GENERAL_CONFIGURATION_FILE,
-            self::createAndInitializeModuleFinder($event)->createGeneralConfigurationYaml()
+        static::createAndWriteFile(
+            static::getApplicationRoot() . static::GENERAL_CONFIGURATION_FILE,
+            static::createAndInitializeModuleFinder($event)->createGeneralConfigurationYaml()
         );
     }
 }

--- a/Classes/Core/Bootstrap.php
+++ b/Classes/Core/Bootstrap.php
@@ -75,7 +75,7 @@ class Bootstrap
     public static function getInstance(): Bootstrap
     {
         if (static::$instance === null) {
-            self::$instance = new static();
+            static::$instance = new static();
         }
 
         return static::$instance;
@@ -90,7 +90,7 @@ class Bootstrap
      */
     public static function purgeInstance()
     {
-        self::$instance = null;
+        static::$instance = null;
     }
 
     /**

--- a/Classes/Core/Environment.php
+++ b/Classes/Core/Environment.php
@@ -59,8 +59,8 @@ final class Environment
      */
     public static function validateEnvironment(string $environment)
     {
-        if (!in_array($environment, self::$validEnvironments, true)) {
-            $environmentsText = '"' . implode('", ', self::$validEnvironments) . '"';
+        if (!in_array($environment, static::$validEnvironments, true)) {
+            $environmentsText = '"' . implode('", ', static::$validEnvironments) . '"';
             throw new \UnexpectedValueException(
                 '$environment must be one of ' . $environmentsText . ', but actually was: "' . $environment . '"',
                 1499112172108

--- a/Classes/Domain/Model/Identity/AdministratorToken.php
+++ b/Classes/Domain/Model/Identity/AdministratorToken.php
@@ -131,7 +131,7 @@ class AdministratorToken implements Identity, CreationDate
      */
     public function generateExpiry()
     {
-        $this->setExpiry(new \DateTime(self::DEFAULT_EXPIRY));
+        $this->setExpiry(new \DateTime(static::DEFAULT_EXPIRY));
     }
 
     /**

--- a/Classes/Routing/ExtraLoader.php
+++ b/Classes/Routing/ExtraLoader.php
@@ -86,7 +86,7 @@ class ExtraLoader extends Loader
     private function addModuleRoutes(RouteCollection $routes)
     {
         $bundleRoutesFilePath = $this->applicationStructure->getApplicationRoot() .
-            self::MODULE_ROUTING_CONFIGURATION_FILE;
+            static::MODULE_ROUTING_CONFIGURATION_FILE;
 
         $routesConfiguration = $this->import($bundleRoutesFilePath);
         $routes->addCollection($routesConfiguration);

--- a/Classes/Security/HashGenerator.php
+++ b/Classes/Security/HashGenerator.php
@@ -22,6 +22,6 @@ class HashGenerator
      */
     public function createPasswordHash(string $plainTextPassword): string
     {
-        return hash(self::PASSWORD_HASH_ALGORITHM, $plainTextPassword);
+        return hash(static::PASSWORD_HASH_ALGORITHM, $plainTextPassword);
     }
 }

--- a/Classes/TestingSupport/Traits/ContainsInstanceAssertionTrait.php
+++ b/Classes/TestingSupport/Traits/ContainsInstanceAssertionTrait.php
@@ -28,6 +28,6 @@ trait ContainsInstanceAssertionTrait
         }
 
         $defaultMessage = 'Failed asserting that an array contains an instance of ' . $className;
-        self::assertTrue($found, $message ?: $defaultMessage);
+        static::assertTrue($found, $message ?: $defaultMessage);
     }
 }

--- a/Classes/TestingSupport/Traits/SimilarDatesAssertionTrait.php
+++ b/Classes/TestingSupport/Traits/SimilarDatesAssertionTrait.php
@@ -24,6 +24,6 @@ trait SimilarDatesAssertionTrait
 
         $difference = $actual->diff($expected, true);
         $differenceInSeconds = $difference->s + $difference->i * 60 + $difference->h * 3600;
-        self::assertLessThan($maximumAllowedDifference, $differenceInSeconds);
+        static::assertLessThan($maximumAllowedDifference, $differenceInSeconds);
     }
 }

--- a/Classes/TestingSupport/Traits/SymfonyServerTrait.php
+++ b/Classes/TestingSupport/Traits/SymfonyServerTrait.php
@@ -58,7 +58,7 @@ trait SymfonyServerTrait
      */
     protected function startSymfonyServer(string $environment)
     {
-        if (!\in_array($environment, self::$validEnvironments, true)) {
+        if (!\in_array($environment, static::$validEnvironments, true)) {
             throw new \InvalidArgumentException('"' . $environment . '" is not a valid environment.', 1516284149961);
         }
         if ($this->lockFileExists()) {
@@ -110,9 +110,9 @@ trait SymfonyServerTrait
     private function waitForServerLockFileToAppear()
     {
         $currentWaitTime = 0;
-        while (!$this->lockFileExists() && $currentWaitTime < self::$maximumWaitTimeForServerLockFile) {
-            \usleep(self::$waitTimeBetweenServerCommands);
-            $currentWaitTime += self::$waitTimeBetweenServerCommands;
+        while (!$this->lockFileExists() && $currentWaitTime < static::$maximumWaitTimeForServerLockFile) {
+            \usleep(static::$waitTimeBetweenServerCommands);
+            $currentWaitTime += static::$waitTimeBetweenServerCommands;
         }
 
         if (!$this->lockFileExists()) {
@@ -168,11 +168,11 @@ trait SymfonyServerTrait
      */
     protected function getApplicationRoot(): string
     {
-        if (self::$applicationStructure === null) {
-            self::$applicationStructure = new ApplicationStructure();
+        if (static::$applicationStructure === null) {
+            static::$applicationStructure = new ApplicationStructure();
         }
 
-        return self::$applicationStructure->getApplicationRoot();
+        return static::$applicationStructure->getApplicationRoot();
     }
 
     /**

--- a/Tests/Integration/AbstractDatabaseTest.php
+++ b/Tests/Integration/AbstractDatabaseTest.php
@@ -61,7 +61,7 @@ abstract class AbstractDatabaseTest extends TestCase
         $this->bootstrap = Bootstrap::getInstance()->setEnvironment(Environment::TESTING)->configure();
         $this->container = $this->bootstrap->getContainer();
         $this->entityManager = $this->bootstrap->getEntityManager();
-        self::assertTrue($this->entityManager->isOpen());
+        static::assertTrue($this->entityManager->isOpen());
     }
 
     /**

--- a/Tests/Integration/Composer/ScriptsTest.php
+++ b/Tests/Integration/Composer/ScriptsTest.php
@@ -25,7 +25,7 @@ class ScriptsTest extends TestCase
      */
     public function bundleConfigurationFileExists()
     {
-        self::assertFileExists($this->getBundleConfigurationFilePath());
+        static::assertFileExists($this->getBundleConfigurationFilePath());
     }
 
     /**
@@ -50,7 +50,7 @@ class ScriptsTest extends TestCase
     {
         $fileContents = file_get_contents($this->getBundleConfigurationFilePath());
 
-        self::assertContains($bundleClassName, $fileContents);
+        static::assertContains($bundleClassName, $fileContents);
     }
 
     /**
@@ -66,7 +66,7 @@ class ScriptsTest extends TestCase
      */
     public function moduleRoutesConfigurationFileExists()
     {
-        self::assertFileExists($this->getModuleRoutesConfigurationFilePath());
+        static::assertFileExists($this->getModuleRoutesConfigurationFilePath());
     }
 
     /**
@@ -90,7 +90,7 @@ class ScriptsTest extends TestCase
     {
         $fileContents = file_get_contents($this->getModuleRoutesConfigurationFilePath());
 
-        self::assertContains($routeSearchString, $fileContents);
+        static::assertContains($routeSearchString, $fileContents);
     }
 
     /**
@@ -98,7 +98,7 @@ class ScriptsTest extends TestCase
      */
     public function parametersConfigurationFileExists()
     {
-        self::assertFileExists(dirname(__DIR__, 3) . '/Configuration/parameters.yml');
+        static::assertFileExists(dirname(__DIR__, 3) . '/Configuration/parameters.yml');
     }
 
     /**
@@ -106,6 +106,6 @@ class ScriptsTest extends TestCase
      */
     public function modulesConfigurationFileExists()
     {
-        self::assertFileExists(dirname(__DIR__, 3) . '/Configuration/config_modules.yml');
+        static::assertFileExists(dirname(__DIR__, 3) . '/Configuration/config_modules.yml');
     }
 }

--- a/Tests/Integration/Core/ApplicationKernelTest.php
+++ b/Tests/Integration/Core/ApplicationKernelTest.php
@@ -44,7 +44,7 @@ class ApplicationKernelTest extends TestCase
      */
     public function getProjectDirReturnsCorePackageRoot()
     {
-        self::assertSame($this->getCorePackageRoot(), $this->subject->getProjectDir());
+        static::assertSame($this->getCorePackageRoot(), $this->subject->getProjectDir());
     }
 
     /**
@@ -52,7 +52,7 @@ class ApplicationKernelTest extends TestCase
      */
     public function getRootDirReturnsCorePackageRoot()
     {
-        self::assertSame($this->getCorePackageRoot(), $this->subject->getRootDir());
+        static::assertSame($this->getCorePackageRoot(), $this->subject->getRootDir());
     }
 
     /**
@@ -68,7 +68,7 @@ class ApplicationKernelTest extends TestCase
      */
     public function getCacheDirReturnsEnvironmentSpecificVarCacheDirectoryInApplicationRoot()
     {
-        self::assertSame(
+        static::assertSame(
             $this->getApplicationRoot() . '/var/cache/' . Environment::TESTING,
             $this->subject->getCacheDir()
         );
@@ -79,7 +79,7 @@ class ApplicationKernelTest extends TestCase
      */
     public function getLogDirReturnsVarLogsDirectoryInApplicationRoot()
     {
-        self::assertSame($this->getApplicationRoot() . '/var/logs', $this->subject->getLogDir());
+        static::assertSame($this->getApplicationRoot() . '/var/logs', $this->subject->getLogDir());
     }
 
     /**
@@ -89,6 +89,6 @@ class ApplicationKernelTest extends TestCase
     {
         $container = $this->subject->getContainer();
 
-        self::assertSame($this->getApplicationRoot(), $container->getParameter('kernel.application_dir'));
+        static::assertSame($this->getApplicationRoot(), $container->getParameter('kernel.application_dir'));
     }
 }

--- a/Tests/Integration/Core/ApplicationStructureTest.php
+++ b/Tests/Integration/Core/ApplicationStructureTest.php
@@ -49,7 +49,7 @@ class ApplicationStructureTest extends TestCase
      */
     public function subjectIsAvailableViaContainer()
     {
-        self::assertInstanceOf(ApplicationStructure::class, $this->container->get(ApplicationStructure::class));
+        static::assertInstanceOf(ApplicationStructure::class, $this->container->get(ApplicationStructure::class));
     }
 
     /**
@@ -59,6 +59,6 @@ class ApplicationStructureTest extends TestCase
     {
         $id = ApplicationStructure::class;
 
-        self::assertSame($this->container->get($id), $this->container->get($id));
+        static::assertSame($this->container->get($id), $this->container->get($id));
     }
 }

--- a/Tests/Integration/Core/BootstrapTest.php
+++ b/Tests/Integration/Core/BootstrapTest.php
@@ -35,7 +35,7 @@ class BootstrapTest extends TestCase
      */
     public function ensureDevelopmentOrTestingEnvironmentForTestingEnvironmentHasFluentInterface()
     {
-        self::assertSame($this->subject, $this->subject->ensureDevelopmentOrTestingEnvironment());
+        static::assertSame($this->subject, $this->subject->ensureDevelopmentOrTestingEnvironment());
     }
 
     /**
@@ -43,6 +43,6 @@ class BootstrapTest extends TestCase
      */
     public function getApplicationRootReturnsCoreApplicationRoot()
     {
-        self::assertSame(dirname(__DIR__, 3), $this->subject->getApplicationRoot());
+        static::assertSame(dirname(__DIR__, 3), $this->subject->getApplicationRoot());
     }
 }

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -39,7 +39,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function findReadsModelFromDatabase()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $id = 1;
@@ -53,15 +53,15 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
         /** @var Administrator $actualModel */
         $actualModel = $this->subject->find($id);
 
-        self::assertSame($id, $actualModel->getId());
-        self::assertSame($loginName, $actualModel->getLoginName());
-        self::assertSame($emailAddress, $actualModel->getEmailAddress());
-        self::assertEquals($creationDate, $actualModel->getCreationDate());
-        self::assertEquals($modificationDate, $actualModel->getModificationDate());
-        self::assertSame($passwordHash, $actualModel->getPasswordHash());
-        self::assertEquals($passwordChangeDate, $actualModel->getPasswordChangeDate());
-        self::assertTrue($actualModel->isDisabled());
-        self::assertTrue($actualModel->isDisabled());
+        static::assertSame($id, $actualModel->getId());
+        static::assertSame($loginName, $actualModel->getLoginName());
+        static::assertSame($emailAddress, $actualModel->getEmailAddress());
+        static::assertEquals($creationDate, $actualModel->getCreationDate());
+        static::assertEquals($modificationDate, $actualModel->getModificationDate());
+        static::assertSame($passwordHash, $actualModel->getPasswordHash());
+        static::assertEquals($passwordChangeDate, $actualModel->getPasswordChangeDate());
+        static::assertTrue($actualModel->isDisabled());
+        static::assertTrue($actualModel->isDisabled());
     }
 
     /**
@@ -69,7 +69,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfExistingModelStaysUnchangedOnUpdate()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $id = 1;
@@ -80,7 +80,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
         $model->setLoginName('mel');
         $this->entityManager->flush();
 
-        self::assertSame($creationDate, $model->getCreationDate());
+        static::assertSame($creationDate, $model->getCreationDate());
     }
 
     /**
@@ -88,7 +88,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function modificationDateOfExistingModelGetsUpdatedOnUpdate()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $id = 1;
@@ -99,7 +99,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
         $model->setLoginName('mel');
         $this->entityManager->flush();
 
-        self::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
+        static::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
     }
 
     /**
@@ -107,7 +107,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $model = new Administrator();
@@ -115,7 +115,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
+        static::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
     }
 
     /**
@@ -123,7 +123,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function modificationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $model = new Administrator();
@@ -131,7 +131,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
+        static::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
     }
 
     /**
@@ -139,7 +139,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function findOneByLoginCredentialsForMatchingCredentialsReturnsModel()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $id = 1;
@@ -148,8 +148,8 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
 
         $result = $this->subject->findOneByLoginCredentials($loginName, $password);
 
-        self::assertInstanceOf(Administrator::class, $result);
-        self::assertSame($id, $result->getId());
+        static::assertInstanceOf(Administrator::class, $result);
+        static::assertSame($id, $result->getId());
     }
 
     /**
@@ -179,7 +179,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
 
         $result = $this->subject->findOneByLoginCredentials($loginName, $password);
 
-        self::assertNull($result);
+        static::assertNull($result);
     }
 
     /**
@@ -192,7 +192,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
     {
         $result = $this->subject->findOneByLoginCredentials($loginName, $password);
 
-        self::assertNull($result);
+        static::assertNull($result);
     }
 
     /**
@@ -200,11 +200,11 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function savePersistsAndFlushesModel()
     {
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new Administrator();
         $this->subject->save($model);
 
-        self::assertSame($model, $this->subject->find($model->getId()));
+        static::assertSame($model, $this->subject->find($model->getId()));
     }
 }

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -47,7 +47,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function findReadsModelFromDatabase()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
         $id = 1;
@@ -58,11 +58,11 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
         /** @var AdministratorToken $model */
         $model = $this->subject->find($id);
 
-        self::assertInstanceOf(AdministratorToken::class, $model);
-        self::assertSame($id, $model->getId());
-        self::assertEquals($creationDate, $model->getCreationDate());
-        self::assertEquals($expiry, $model->getExpiry());
-        self::assertSame($key, $model->getKey());
+        static::assertInstanceOf(AdministratorToken::class, $model);
+        static::assertSame($id, $model->getId());
+        static::assertEquals($creationDate, $model->getCreationDate());
+        static::assertEquals($expiry, $model->getExpiry());
+        static::assertSame($key, $model->getKey());
     }
 
     /**
@@ -70,9 +70,9 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function createsAdministratorAssociationAsProxy()
     {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
         $this->getDataSet()->addTable(
-            self::TABLE_NAME,
+            static::TABLE_NAME,
             __DIR__ . '/../Fixtures/AdministratorTokenWithAdministrator.csv'
         );
         $this->applyDatabaseChanges();
@@ -83,9 +83,9 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
         $model = $this->subject->find($tokenId);
         $administrator = $model->getAdministrator();
 
-        self::assertInstanceOf(Administrator::class, $administrator);
-        self::assertInstanceOf(Proxy::class, $administrator);
-        self::assertSame($administratorId, $administrator->getId());
+        static::assertInstanceOf(Administrator::class, $administrator);
+        static::assertInstanceOf(Proxy::class, $administrator);
+        static::assertSame($administratorId, $administrator->getId());
     }
 
     /**
@@ -93,7 +93,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfExistingModelStaysUnchangedOnUpdate()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
         $id = 1;
@@ -104,7 +104,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
         $model->setKey('asdfasd');
         $this->entityManager->flush();
 
-        self::assertEquals($creationDate, $model->getCreationDate());
+        static::assertEquals($creationDate, $model->getCreationDate());
     }
 
     /**
@@ -112,7 +112,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
         $model = new Administrator();
@@ -120,7 +120,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
+        static::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
     }
 
     /**
@@ -128,7 +128,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function findOneUnexpiredByKeyFindsUnexpiredTokenWithMatchingKey()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
         $id = 2;
@@ -137,8 +137,8 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
         /** @var AdministratorToken $model */
         $model = $this->subject->findOneUnexpiredByKey($key);
 
-        self::assertInstanceOf(AdministratorToken::class, $model);
-        self::assertSame($id, $model->getId());
+        static::assertInstanceOf(AdministratorToken::class, $model);
+        static::assertSame($id, $model->getId());
     }
 
     /**
@@ -146,14 +146,14 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function findOneUnexpiredByKeyNotFindsExpiredTokenWithMatchingKey()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
         $key = 'cfdf64eecbbf336628b0f3071adba762';
 
         $model = $this->subject->findOneUnexpiredByKey($key);
 
-        self::assertNull($model);
+        static::assertNull($model);
     }
 
     /**
@@ -161,14 +161,14 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function findOneUnexpiredByKeyNotFindsUnexpiredTokenWithNonMatchingKey()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
         $key = '03e7a64fb29115ba7581092c342299df';
 
         $model = $this->subject->findOneUnexpiredByKey($key);
 
-        self::assertNull($model);
+        static::assertNull($model);
     }
 
     /**
@@ -176,14 +176,14 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function removeExpiredRemovesExpiredToken()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
         $idOfExpiredToken = 1;
         $this->subject->removeExpired();
 
         $token = $this->subject->find($idOfExpiredToken);
-        self::assertNull($token);
+        static::assertNull($token);
     }
 
     /**
@@ -193,14 +193,14 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
     {
         $this->assertNotYear2037Yet();
 
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
         $idOfUnexpiredToken = 2;
         $this->subject->removeExpired();
 
         $token = $this->subject->find($idOfUnexpiredToken);
-        self::assertNotNull($token);
+        static::assertNotNull($token);
     }
 
     /**
@@ -213,7 +213,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
     {
         $currentYear = (int)date('Y');
         if ($currentYear >= 2037) {
-            self::markTestIncomplete('The tests token has an expiry in the year 2037. Please update this test.');
+            static::markTestIncomplete('The tests token has an expiry in the year 2037. Please update this test.');
         }
     }
 
@@ -222,7 +222,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function removeExpiredForNoExpiredTokensReturnsZero()
     {
-        self::assertSame(0, $this->subject->removeExpired());
+        static::assertSame(0, $this->subject->removeExpired());
     }
 
     /**
@@ -232,10 +232,10 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
     {
         $this->assertNotYear2037Yet();
 
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
         $this->applyDatabaseChanges();
 
-        self::assertSame(1, $this->subject->removeExpired());
+        static::assertSame(1, $this->subject->removeExpired());
     }
 
     /**
@@ -243,8 +243,8 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function savePersistsAndFlushesModel()
     {
-        $this->touchDatabaseTable(self::TABLE_NAME);
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->touchDatabaseTable(static::TABLE_NAME);
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $administratorRepository = $this->container->get(AdministratorRepository::class);
@@ -255,6 +255,6 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
         $model->setAdministrator($administrator);
         $this->subject->save($model);
 
-        self::assertSame($model, $this->subject->find($model->getId()));
+        static::assertSame($model, $this->subject->find($model->getId()));
     }
 }

--- a/Tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
@@ -71,7 +71,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function findReadsModelFromDatabase()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $id = 1;
@@ -86,15 +86,15 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
         /** @var SubscriberList $model */
         $model = $this->subject->find($id);
 
-        self::assertSame($id, $model->getId());
-        self::assertEquals($creationDate, $model->getCreationDate());
-        self::assertEquals($modificationDate, $model->getModificationDate());
-        self::assertSame($name, $model->getName());
-        self::assertSame($description, $model->getDescription());
-        self::assertSame($listPosition, $model->getListPosition());
-        self::assertSame($subjectPrefix, $model->getSubjectPrefix());
-        self::assertTrue($model->isPublic());
-        self::assertSame($category, $model->getCategory());
+        static::assertSame($id, $model->getId());
+        static::assertEquals($creationDate, $model->getCreationDate());
+        static::assertEquals($modificationDate, $model->getModificationDate());
+        static::assertSame($name, $model->getName());
+        static::assertSame($description, $model->getDescription());
+        static::assertSame($listPosition, $model->getListPosition());
+        static::assertSame($subjectPrefix, $model->getSubjectPrefix());
+        static::assertTrue($model->isPublic());
+        static::assertSame($category, $model->getCategory());
     }
 
     /**
@@ -102,8 +102,8 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function createsOwnerAssociationAsProxy()
     {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $subscriberListId = 1;
@@ -112,9 +112,9 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
         $model = $this->subject->find($subscriberListId);
         $owner = $model->getOwner();
 
-        self::assertInstanceOf(Administrator::class, $owner);
-        self::assertInstanceOf(Proxy::class, $owner);
-        self::assertSame($ownerId, $owner->getId());
+        static::assertInstanceOf(Administrator::class, $owner);
+        static::assertInstanceOf(Proxy::class, $owner);
+        static::assertSame($ownerId, $owner->getId());
     }
 
     /**
@@ -122,7 +122,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $model = new SubscriberList();
@@ -130,7 +130,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
+        static::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
     }
 
     /**
@@ -138,7 +138,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function modificationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $model = new SubscriberList();
@@ -146,7 +146,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
+        static::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
     }
 
     /**
@@ -154,12 +154,12 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function savePersistsAndFlushesModel()
     {
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new SubscriberList();
         $this->subject->save($model);
 
-        self::assertSame($model, $this->subject->find($model->getId()));
+        static::assertSame($model, $this->subject->find($model->getId()));
     }
 
     /**
@@ -167,8 +167,8 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function findByOwnerFindsSubscriberListWithTheGivenOwner()
     {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $owner = $this->administratorRepository->find(1);
@@ -176,7 +176,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
 
         $result = $this->subject->findByOwner($owner);
 
-        self::assertContains($ownedList, $result);
+        static::assertContains($ownedList, $result);
     }
 
     /**
@@ -184,8 +184,8 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function findByOwnerIgnoresSubscriberListWithOtherOwner()
     {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $owner = $this->administratorRepository->find(1);
@@ -193,7 +193,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
 
         $result = $this->subject->findByOwner($owner);
 
-        self::assertNotContains($foreignList, $result);
+        static::assertNotContains($foreignList, $result);
     }
 
     /**
@@ -201,8 +201,8 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function findByOwnerIgnoresSubscriberListFromOtherOwner()
     {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $owner = $this->administratorRepository->find(1);
@@ -210,7 +210,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
 
         $result = $this->subject->findByOwner($owner);
 
-        self::assertNotContains($unownedList, $result);
+        static::assertNotContains($unownedList, $result);
     }
 
     /**
@@ -218,9 +218,9 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function findsAssociatedSubscriptions()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
         $this->applyDatabaseChanges();
 
         /** @var SubscriberList $model */
@@ -228,12 +228,12 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
         $model = $this->subject->find($id);
         $subscriptions = $model->getSubscriptions();
 
-        self::assertFalse($subscriptions->isEmpty());
+        static::assertFalse($subscriptions->isEmpty());
         /** @var Subscription $firstSubscription */
         $firstSubscription = $subscriptions->first();
-        self::assertInstanceOf(Subscription::class, $firstSubscription);
+        static::assertInstanceOf(Subscription::class, $firstSubscription);
         $expectedSubscriberId = 1;
-        self::assertSame($expectedSubscriberId, $firstSubscription->getSubscriber()->getId());
+        static::assertSame($expectedSubscriberId, $firstSubscription->getSubscriber()->getId());
     }
 
     /**
@@ -241,9 +241,9 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function findsAssociatedSubscribers()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
         $this->applyDatabaseChanges();
 
         /** @var SubscriberList $model */
@@ -253,7 +253,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
 
         $expectedSubscriber = $this->subscriberRepository->find(1);
         $unexpectedSubscriber = $this->subscriberRepository->find(3);
-        self::assertTrue($subscribers->contains($expectedSubscriber));
-        self::assertFalse($subscribers->contains($unexpectedSubscriber));
+        static::assertTrue($subscribers->contains($expectedSubscriber));
+        static::assertFalse($subscribers->contains($unexpectedSubscriber));
     }
 }

--- a/Tests/Integration/Domain/Repository/Subscription/SubscriberRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Subscription/SubscriberRepositoryTest.php
@@ -63,7 +63,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function findReadsModelFromDatabase()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
         $this->applyDatabaseChanges();
 
         $id = 1;
@@ -73,16 +73,16 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
         /** @var Subscriber $model */
         $model = $this->subject->find($id);
 
-        self::assertSame($id, $model->getId());
-        self::assertEquals($creationDate, $model->getCreationDate());
-        self::assertEquals($modificationDate, $model->getModificationDate());
-        self::assertEquals('oliver@example.com', $model->getEmail());
-        self::assertTrue($model->isConfirmed());
-        self::assertTrue($model->isBlacklisted());
-        self::assertSame(17, $model->getBounceCount());
-        self::assertSame('95feb7fe7e06e6c11ca8d0c48cb46e89', $model->getUniqueId());
-        self::assertTrue($model->hasHtmlEmail());
-        self::assertTrue($model->isDisabled());
+        static::assertSame($id, $model->getId());
+        static::assertEquals($creationDate, $model->getCreationDate());
+        static::assertEquals($modificationDate, $model->getModificationDate());
+        static::assertEquals('oliver@example.com', $model->getEmail());
+        static::assertTrue($model->isConfirmed());
+        static::assertTrue($model->isBlacklisted());
+        static::assertSame(17, $model->getBounceCount());
+        static::assertSame('95feb7fe7e06e6c11ca8d0c48cb46e89', $model->getUniqueId());
+        static::assertTrue($model->hasHtmlEmail());
+        static::assertTrue($model->isDisabled());
     }
 
     /**
@@ -90,7 +90,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new Subscriber();
         $model->setEmail('sam@example.com');
@@ -98,7 +98,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
+        static::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
     }
 
     /**
@@ -106,7 +106,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function modificationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new Subscriber();
         $model->setEmail('oliver@example.com');
@@ -114,7 +114,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
+        static::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
     }
 
     /**
@@ -122,13 +122,13 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function savePersistsAndFlushesModel()
     {
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new Subscriber();
         $model->setEmail('michiel@example.com');
         $this->subject->save($model);
 
-        self::assertSame($model, $this->subject->find($model->getId()));
+        static::assertSame($model, $this->subject->find($model->getId()));
     }
 
     /**
@@ -136,7 +136,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function emailMustBeUnique()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
         $this->applyDatabaseChanges();
 
         /** @var Subscriber $model */
@@ -156,14 +156,14 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function uniqueIdOfNewModelIsGeneratedOnPersist()
     {
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new Subscriber();
         $model->setEmail('oliver@example.com');
 
         $this->entityManager->persist($model);
 
-        self::assertRegExp('/^[0-9a-f]{32}$/', $model->getUniqueId());
+        static::assertRegExp('/^[0-9a-f]{32}$/', $model->getUniqueId());
     }
 
     /**
@@ -171,7 +171,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function persistingExistingModelKeepsUniqueIdUnchanged()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
         $this->applyDatabaseChanges();
 
         /** @var Subscriber $model */
@@ -181,7 +181,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
         $model->setEmail('other@example.com');
         $this->entityManager->persist($model);
 
-        self::assertSame($oldUniqueId, $model->getUniqueId());
+        static::assertSame($oldUniqueId, $model->getUniqueId());
     }
 
     /**
@@ -191,14 +191,14 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
     {
         $email = 'oliver@example.com';
 
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
         $this->applyDatabaseChanges();
 
         /** @var Subscriber $model */
         $model = $this->subject->findOneByEmail($email);
 
-        self::assertInstanceOf(Subscriber::class, $model);
-        self::assertSame($email, $model->getEmail());
+        static::assertInstanceOf(Subscriber::class, $model);
+        static::assertSame($email, $model->getEmail());
     }
 
     /**
@@ -208,12 +208,12 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
     {
         $email = 'other@example.com';
 
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
         $this->applyDatabaseChanges();
 
         $model = $this->subject->findOneByEmail($email);
 
-        self::assertNull($model);
+        static::assertNull($model);
     }
 
     /**
@@ -221,9 +221,9 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function findsAssociatedSubscriptions()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
         $this->applyDatabaseChanges();
 
         /** @var Subscriber $model */
@@ -231,12 +231,12 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
         $model = $this->subject->find($id);
         $subscriptions = $model->getSubscriptions();
 
-        self::assertFalse($subscriptions->isEmpty());
+        static::assertFalse($subscriptions->isEmpty());
         /** @var Subscription $firstSubscription */
         $firstSubscription = $subscriptions->first();
-        self::assertInstanceOf(Subscription::class, $firstSubscription);
+        static::assertInstanceOf(Subscription::class, $firstSubscription);
         $expectedSubscriberListId = 2;
-        self::assertSame($expectedSubscriberListId, $firstSubscription->getSubscriberList()->getId());
+        static::assertSame($expectedSubscriberListId, $firstSubscription->getSubscriberList()->getId());
     }
 
     /**
@@ -244,9 +244,9 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
      */
     public function findsAssociatedSubscribedLists()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
         $this->applyDatabaseChanges();
 
         /** @var Subscriber $model */
@@ -256,7 +256,7 @@ class SubscriberRepositoryTest extends AbstractDatabaseTest
 
         $expectedList = $this->subscriberListRepository->find(2);
         $unexpectedList = $this->subscriberListRepository->find(1);
-        self::assertTrue($subscribedLists->contains($expectedList));
-        self::assertFalse($subscribedLists->contains($unexpectedList));
+        static::assertTrue($subscribedLists->contains($expectedList));
+        static::assertFalse($subscribedLists->contains($unexpectedList));
     }
 }

--- a/Tests/Integration/Domain/Repository/Subscription/SubscriptionRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Subscription/SubscriptionRepositoryTest.php
@@ -72,7 +72,7 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
      */
     public function findAllReadsModelsFromDatabase()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
         $this->applyDatabaseChanges();
 
         $creationDate = new \DateTime('2016-07-22 15:01:17');
@@ -81,12 +81,12 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
         /** @var Subscription[] $result */
         $result = $this->subject->findAll();
 
-        self::assertNotEmpty($result);
+        static::assertNotEmpty($result);
 
         $model = $result[0];
-        self::assertInstanceOf(Subscription::class, $model);
-        self::assertEquals($creationDate, $model->getCreationDate());
-        self::assertEquals($modificationDate, $model->getModificationDate());
+        static::assertInstanceOf(Subscription::class, $model);
+        static::assertEquals($creationDate, $model->getCreationDate());
+        static::assertEquals($modificationDate, $model->getModificationDate());
     }
 
     /**
@@ -94,8 +94,8 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
      */
     public function createsSubscriberAssociationAsProxy()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
         $this->applyDatabaseChanges();
 
         $subscriberId = 1;
@@ -103,9 +103,9 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
         $model = $this->subject->findAll()[0];
         $subscriber = $model->getSubscriber();
 
-        self::assertInstanceOf(Subscriber::class, $subscriber);
-        self::assertInstanceOf(Proxy::class, $subscriber);
-        self::assertSame($subscriberId, $subscriber->getId());
+        static::assertInstanceOf(Subscriber::class, $subscriber);
+        static::assertInstanceOf(Proxy::class, $subscriber);
+        static::assertSame($subscriberId, $subscriber->getId());
     }
 
     /**
@@ -113,8 +113,8 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
      */
     public function createsSubscriberListAssociationAsProxy()
     {
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $subscriberListId = 2;
@@ -122,9 +122,9 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
         $model = $this->subject->findAll()[0];
         $subscriberList = $model->getSubscriberList();
 
-        self::assertInstanceOf(SubscriberList::class, $subscriberList);
-        self::assertInstanceOf(Proxy::class, $subscriberList);
-        self::assertSame($subscriberListId, $subscriberList->getId());
+        static::assertInstanceOf(SubscriberList::class, $subscriberList);
+        static::assertInstanceOf(Proxy::class, $subscriberList);
+        static::assertSame($subscriberListId, $subscriberList->getId());
     }
 
     /**
@@ -132,9 +132,9 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->touchDatabaseTable(static::TABLE_NAME);
         $this->applyDatabaseChanges();
 
         $model = new Subscription();
@@ -148,7 +148,7 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
+        static::assertSimilarDates($expectedCreationDate, $model->getCreationDate());
     }
 
     /**
@@ -156,9 +156,9 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
      */
     public function modificationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_LIST_TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->touchDatabaseTable(static::TABLE_NAME);
         $this->applyDatabaseChanges();
 
         $model = new Subscription();
@@ -172,7 +172,7 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
 
         $this->entityManager->persist($model);
 
-        self::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
+        static::assertSimilarDates($expectedModificationDate, $model->getModificationDate());
     }
 
     /**
@@ -180,9 +180,9 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
      */
     public function findBySubscriberFindsSubscriptionOnlyWithTheGivenSubscriber()
     {
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->touchDatabaseTable(static::TABLE_NAME);
         $this->applyDatabaseChanges();
 
         /** @var Subscriber $subscriber */
@@ -192,7 +192,7 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
 
         /** @var Subscription $subscription */
         foreach ($result as $subscription) {
-            self::assertSame($subscriber, $subscription->getSubscriber());
+            static::assertSame($subscriber, $subscription->getSubscriber());
         }
     }
 
@@ -201,9 +201,9 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
      */
     public function findBySubscriberListFindsSubscriptionOnlyWithTheGivenSubscriberList()
     {
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
-        $this->touchDatabaseTable(self::TABLE_NAME);
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->touchDatabaseTable(static::TABLE_NAME);
         $this->applyDatabaseChanges();
 
         /** @var SubscriberList $subscriberList */
@@ -213,7 +213,7 @@ class SubscriptionRepositoryTest extends AbstractDatabaseTest
 
         /** @var Subscription $subscription */
         foreach ($result as $subscription) {
-            self::assertSame($subscriberList, $subscription->getSubscriberList());
+            static::assertSame($subscriberList, $subscription->getSubscriberList());
         }
     }
 }

--- a/Tests/Integration/EmptyStartPageBundle/Controller/DefaultControllerTest.php
+++ b/Tests/Integration/EmptyStartPageBundle/Controller/DefaultControllerTest.php
@@ -25,7 +25,7 @@ class DefaultControllerTest extends WebTestCase
     {
         Bootstrap::getInstance()->setEnvironment(Environment::TESTING)->configure();
 
-        $this->client = self::createClient(['environment' => Environment::TESTING]);
+        $this->client = static::createClient(['environment' => Environment::TESTING]);
     }
 
     /**
@@ -33,7 +33,10 @@ class DefaultControllerTest extends WebTestCase
      */
     public function controllerIsAvailableViaContainer()
     {
-        self::assertInstanceOf(DefaultController::class, $this->client->getContainer()->get(DefaultController::class));
+        static::assertInstanceOf(
+            DefaultController::class,
+            $this->client->getContainer()->get(DefaultController::class)
+        );
     }
 
     /**
@@ -43,8 +46,8 @@ class DefaultControllerTest extends WebTestCase
     {
         $this->client->request('GET', '/');
 
-        self::assertTrue($this->client->getResponse()->isSuccessful());
-        self::assertContains(
+        static::assertTrue($this->client->getResponse()->isSuccessful());
+        static::assertContains(
             'This page has been intentionally left empty.',
             $this->client->getResponse()->getContent()
         );

--- a/Tests/Integration/Routing/ExtraLoaderTest.php
+++ b/Tests/Integration/Routing/ExtraLoaderTest.php
@@ -69,6 +69,6 @@ class ExtraLoaderTest extends TestCase
      */
     public function loadReturnsRouteCollection()
     {
-        self::assertInstanceOf(RouteCollection::class, $this->subject->load('', 'extra'));
+        static::assertInstanceOf(RouteCollection::class, $this->subject->load('', 'extra'));
     }
 }

--- a/Tests/Integration/Security/AuthenticationTest.php
+++ b/Tests/Integration/Security/AuthenticationTest.php
@@ -42,7 +42,7 @@ class AuthenticationTest extends AbstractDatabaseTest
      */
     public function subjectIsAvailableViaContainer()
     {
-        self::assertInstanceOf(Authentication::class, $this->subject);
+        static::assertInstanceOf(Authentication::class, $this->subject);
     }
 
     /**
@@ -50,7 +50,7 @@ class AuthenticationTest extends AbstractDatabaseTest
      */
     public function classIsRegisteredAsSingletonInContainer()
     {
-        self::assertSame($this->subject, $this->container->get(Authentication::class));
+        static::assertSame($this->subject, $this->container->get(Authentication::class));
     }
 
     /**
@@ -59,11 +59,11 @@ class AuthenticationTest extends AbstractDatabaseTest
     public function authenticateByApiKeyWithValidApiKeyReturnsMatchingAdministrator()
     {
         $this->getDataSet()->addTable(
-            self::ADMINISTRATOR_TABLE_NAME,
+            static::ADMINISTRATOR_TABLE_NAME,
             __DIR__ . '/../Domain/Repository/Fixtures/Administrator.csv'
         );
         $this->getDataSet()->addTable(
-            self::TOKEN_TABLE_NAME,
+            static::TOKEN_TABLE_NAME,
             __DIR__ . '/../Domain/Repository/Fixtures/AdministratorTokenWithAdministrator.csv'
         );
         $this->applyDatabaseChanges();
@@ -74,8 +74,8 @@ class AuthenticationTest extends AbstractDatabaseTest
 
         $result = $this->subject->authenticateByApiKey($request);
 
-        self::assertInstanceOf(Administrator::class, $result);
-        self::assertSame(1, $result->getId());
+        static::assertInstanceOf(Administrator::class, $result);
+        static::assertSame(1, $result->getId());
     }
 
     /**
@@ -84,7 +84,7 @@ class AuthenticationTest extends AbstractDatabaseTest
     public function authenticateByApiKeyWithValidApiKeyForInexistentAdministratorReturnsNull()
     {
         $this->getDataSet()->addTable(
-            self::TOKEN_TABLE_NAME,
+            static::TOKEN_TABLE_NAME,
             __DIR__ . '/../Domain/Repository/Fixtures/AdministratorTokenWithAdministrator.csv'
         );
         $this->applyDatabaseChanges();
@@ -95,7 +95,7 @@ class AuthenticationTest extends AbstractDatabaseTest
 
         $result = $this->subject->authenticateByApiKey($request);
 
-        self::assertNull($result);
+        static::assertNull($result);
     }
 
     /**
@@ -104,7 +104,7 @@ class AuthenticationTest extends AbstractDatabaseTest
     public function authenticateByApiKeyWithValidApiKeyForNonSuperUserAdministratorReturnsNull()
     {
         $this->getDataSet()->addTable(
-            self::TOKEN_TABLE_NAME,
+            static::TOKEN_TABLE_NAME,
             __DIR__ . '/../Domain/Repository/Fixtures/AdministratorTokenWithAdministrator.csv'
         );
         $this->applyDatabaseChanges();
@@ -115,6 +115,6 @@ class AuthenticationTest extends AbstractDatabaseTest
 
         $result = $this->subject->authenticateByApiKey($request);
 
-        self::assertNull($result);
+        static::assertNull($result);
     }
 }

--- a/Tests/Integration/Security/HashGeneratorTest.php
+++ b/Tests/Integration/Security/HashGeneratorTest.php
@@ -49,7 +49,7 @@ class HashGeneratorTest extends TestCase
      */
     public function subjectIsAvailableViaContainer()
     {
-        self::assertInstanceOf(HashGenerator::class, $this->container->get(HashGenerator::class));
+        static::assertInstanceOf(HashGenerator::class, $this->container->get(HashGenerator::class));
     }
 
     /**
@@ -59,6 +59,6 @@ class HashGeneratorTest extends TestCase
     {
         $id = HashGenerator::class;
 
-        self::assertSame($this->container->get($id), $this->container->get($id));
+        static::assertSame($this->container->get($id), $this->container->get($id));
     }
 }

--- a/Tests/System/ApplicationBundle/PhpListApplicationBundleTest.php
+++ b/Tests/System/ApplicationBundle/PhpListApplicationBundleTest.php
@@ -53,7 +53,7 @@ class PhpListApplicationBundleTest extends TestCase
 
         $response = $this->httpClient->get('/', ['base_uri' => $this->getBaseUrl()]);
 
-        self::assertSame(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -67,6 +67,6 @@ class PhpListApplicationBundleTest extends TestCase
 
         $response = $this->httpClient->get('/', ['base_uri' => $this->getBaseUrl()]);
 
-        self::assertContains('This page has been intentionally left empty.', $response->getBody()->getContents());
+        static::assertContains('This page has been intentionally left empty.', $response->getBody()->getContents());
     }
 }

--- a/Tests/Unit/Composer/ModuleFinderTest.php
+++ b/Tests/Unit/Composer/ModuleFinderTest.php
@@ -53,7 +53,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->findBundleClasses();
 
-        self::assertSame([], $result);
+        static::assertSame([], $result);
     }
 
     /**
@@ -131,7 +131,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->findBundleClasses();
 
-        self::assertSame([], $result);
+        static::assertSame([], $result);
     }
 
     /**
@@ -259,7 +259,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->findBundleClasses();
 
-        self::assertSame($expectedBundles, $result);
+        static::assertSame($expectedBundles, $result);
     }
 
     /**
@@ -271,7 +271,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->createBundleConfigurationYaml();
 
-        self::assertSame(self::YAML_COMMENT . "\n{  }", $result);
+        static::assertSame(static::YAML_COMMENT . "\n{  }", $result);
     }
 
     /**
@@ -286,7 +286,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->createBundleConfigurationYaml();
 
-        self::assertSame(self::YAML_COMMENT . "\n" . Yaml::dump($bundles), $result);
+        static::assertSame(static::YAML_COMMENT . "\n" . Yaml::dump($bundles), $result);
     }
 
     /**
@@ -316,7 +316,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->findRoutes();
 
-        self::assertSame([], $result);
+        static::assertSame([], $result);
     }
 
     /**
@@ -488,7 +488,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->findRoutes();
 
-        self::assertSame($expectedRoutes, $result);
+        static::assertSame($expectedRoutes, $result);
     }
 
     /**
@@ -500,7 +500,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->createRouteConfigurationYaml();
 
-        self::assertSame(self::YAML_COMMENT . "\n{  }", $result);
+        static::assertSame(static::YAML_COMMENT . "\n{  }", $result);
     }
 
     /**
@@ -515,7 +515,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->createRouteConfigurationYaml();
 
-        self::assertSame(self::YAML_COMMENT . "\n" . Yaml::dump($routes), $result);
+        static::assertSame(static::YAML_COMMENT . "\n" . Yaml::dump($routes), $result);
     }
 
     /**
@@ -545,7 +545,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->findGeneralConfiguration();
 
-        self::assertSame([], $result);
+        static::assertSame([], $result);
     }
 
     /**
@@ -664,7 +664,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->findGeneralConfiguration();
 
-        self::assertSame($expectedConfiguration, $result);
+        static::assertSame($expectedConfiguration, $result);
     }
 
     /**
@@ -676,7 +676,7 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->createGeneralConfigurationYaml();
 
-        self::assertSame(self::YAML_COMMENT . "\n{  }", $result);
+        static::assertSame(static::YAML_COMMENT . "\n{  }", $result);
     }
 
     /**
@@ -691,6 +691,6 @@ class ModuleFinderTest extends TestCase
 
         $result = $this->subject->createGeneralConfigurationYaml();
 
-        self::assertSame(self::YAML_COMMENT . "\n" . Yaml::dump($routes), $result);
+        static::assertSame(static::YAML_COMMENT . "\n" . Yaml::dump($routes), $result);
     }
 }

--- a/Tests/Unit/Composer/PackageRepositoryTest.php
+++ b/Tests/Unit/Composer/PackageRepositoryTest.php
@@ -77,7 +77,7 @@ class PackageRepositoryTest extends TestCase
         $dependency = $dependencyProphecy->reveal();
         $this->localRepositoryProphecy->getPackages()->willReturn([$dependency]);
 
-        self::assertContains($dependency, $this->subject->findAll());
+        static::assertContains($dependency, $this->subject->findAll());
     }
 
     /**
@@ -91,7 +91,7 @@ class PackageRepositoryTest extends TestCase
 
         $this->localRepositoryProphecy->getPackages()->willReturn([]);
 
-        self::assertContains($rootPackage, $this->subject->findAll());
+        static::assertContains($rootPackage, $this->subject->findAll());
     }
 
     /**
@@ -115,7 +115,7 @@ class PackageRepositoryTest extends TestCase
         $dependencyAlias = $dependencyAliasProphecy->reveal();
         $this->localRepositoryProphecy->getPackages()->willReturn([$dependency, $dependencyAlias]);
 
-        self::assertNotContains($dependencyAlias, $this->subject->findAll());
+        static::assertNotContains($dependencyAlias, $this->subject->findAll());
     }
 
     /**
@@ -133,7 +133,7 @@ class PackageRepositoryTest extends TestCase
 
         $this->localRepositoryProphecy->getPackages()->willReturn([]);
 
-        self::assertContains($rootPackage, $this->subject->findModules());
+        static::assertContains($rootPackage, $this->subject->findModules());
     }
 
     /**
@@ -156,7 +156,7 @@ class PackageRepositoryTest extends TestCase
 
         $this->localRepositoryProphecy->getPackages()->willReturn([$dependency]);
 
-        self::assertContains($dependency, $this->subject->findModules());
+        static::assertContains($dependency, $this->subject->findModules());
     }
 
     /**
@@ -189,7 +189,7 @@ class PackageRepositoryTest extends TestCase
 
         $this->localRepositoryProphecy->getPackages()->willReturn([]);
 
-        self::assertNotContains($rootPackage, $this->subject->findModules());
+        static::assertNotContains($rootPackage, $this->subject->findModules());
     }
 
     /**
@@ -214,6 +214,6 @@ class PackageRepositoryTest extends TestCase
 
         $this->localRepositoryProphecy->getPackages()->willReturn([$dependency]);
 
-        self::assertNotContains($dependency, $this->subject->findModules());
+        static::assertNotContains($dependency, $this->subject->findModules());
     }
 }

--- a/Tests/Unit/Composer/ScriptHandlerTest.php
+++ b/Tests/Unit/Composer/ScriptHandlerTest.php
@@ -111,7 +111,7 @@ class ScriptHandlerTest extends TestCase
         ScriptHandler::listModules($event);
 
         $output = $this->getActualOutput();
-        self::assertNotContains($rootPackageName, $output);
+        static::assertNotContains($rootPackageName, $output);
     }
 
     /**
@@ -168,7 +168,7 @@ class ScriptHandlerTest extends TestCase
         ScriptHandler::listModules($event);
 
         $output = $this->getActualOutput();
-        self::assertNotContains($dependencyPackageName, $output);
+        static::assertNotContains($dependencyPackageName, $output);
     }
 
     /**

--- a/Tests/Unit/Core/ApplicationKernelTest.php
+++ b/Tests/Unit/Core/ApplicationKernelTest.php
@@ -43,7 +43,7 @@ class ApplicationKernelTest extends TestCase
      */
     public function isKernelInstance()
     {
-        self::assertInstanceOf(Kernel::class, $this->subject);
+        static::assertInstanceOf(Kernel::class, $this->subject);
     }
 
     /**
@@ -53,7 +53,7 @@ class ApplicationKernelTest extends TestCase
     {
         $bundles = $this->subject->registerBundles();
 
-        self::assertContainsOnlyInstancesOf(BundleInterface::class, $bundles);
+        static::assertContainsOnlyInstancesOf(BundleInterface::class, $bundles);
     }
 
     /**
@@ -77,6 +77,6 @@ class ApplicationKernelTest extends TestCase
     {
         $bundles = $this->subject->registerBundles();
 
-        self::assertContainsInstanceOf($className, $bundles);
+        static::assertContainsInstanceOf($className, $bundles);
     }
 }

--- a/Tests/Unit/Core/ApplicationStructureTest.php
+++ b/Tests/Unit/Core/ApplicationStructureTest.php
@@ -28,7 +28,7 @@ class ApplicationStructureTest extends TestCase
      */
     public function getApplicationRootReturnsCoreApplicationRoot()
     {
-        self::assertSame(dirname(__DIR__, 3), $this->subject->getApplicationRoot());
+        static::assertSame(dirname(__DIR__, 3), $this->subject->getApplicationRoot());
     }
 
     /**
@@ -36,6 +36,6 @@ class ApplicationStructureTest extends TestCase
      */
     public function getCorePackageRootReturnsCorePackageRoot()
     {
-        self::assertSame(dirname(__DIR__, 3), $this->subject->getCorePackageRoot());
+        static::assertSame(dirname(__DIR__, 3), $this->subject->getCorePackageRoot());
     }
 }

--- a/Tests/Unit/Core/BootstrapTest.php
+++ b/Tests/Unit/Core/BootstrapTest.php
@@ -38,7 +38,7 @@ class BootstrapTest extends TestCase
      */
     public function getInstanceReturnsBootstrapInstance()
     {
-        self::assertInstanceOf(Bootstrap::class, Bootstrap::getInstance());
+        static::assertInstanceOf(Bootstrap::class, Bootstrap::getInstance());
     }
 
     /**
@@ -46,7 +46,7 @@ class BootstrapTest extends TestCase
      */
     public function classIsSingleton()
     {
-        self::assertSame(Bootstrap::getInstance(), Bootstrap::getInstance());
+        static::assertSame(Bootstrap::getInstance(), Bootstrap::getInstance());
     }
 
     /**
@@ -59,7 +59,7 @@ class BootstrapTest extends TestCase
         Bootstrap::purgeInstance();
 
         $secondInstance = Bootstrap::getInstance();
-        self::assertNotSame($firstInstance, $secondInstance);
+        static::assertNotSame($firstInstance, $secondInstance);
     }
 
     /**
@@ -71,7 +71,7 @@ class BootstrapTest extends TestCase
 
         $subject = Bootstrap::getInstance();
 
-        self::assertSame(Environment::PRODUCTION, $subject->getEnvironment());
+        static::assertSame(Environment::PRODUCTION, $subject->getEnvironment());
     }
 
     /**
@@ -79,7 +79,7 @@ class BootstrapTest extends TestCase
      */
     public function setEnvironmentHasFluentInterface()
     {
-        self::assertSame($this->subject, $this->subject->setEnvironment(Environment::TESTING));
+        static::assertSame($this->subject, $this->subject->setEnvironment(Environment::TESTING));
     }
 
     /**
@@ -103,7 +103,7 @@ class BootstrapTest extends TestCase
     {
         $this->subject->setEnvironment($environment);
 
-        self::assertSame($environment, $this->subject->getEnvironment());
+        static::assertSame($environment, $this->subject->getEnvironment());
     }
 
     /**
@@ -121,7 +121,7 @@ class BootstrapTest extends TestCase
      */
     public function configureHasFluentInterface()
     {
-        self::assertSame($this->subject, $this->subject->configure());
+        static::assertSame($this->subject, $this->subject->configure());
     }
 
     /**
@@ -131,7 +131,7 @@ class BootstrapTest extends TestCase
     {
         $this->subject->configure();
 
-        self::assertInstanceOf(ApplicationKernel::class, $this->subject->getApplicationKernel());
+        static::assertInstanceOf(ApplicationKernel::class, $this->subject->getApplicationKernel());
     }
 
     /**
@@ -161,7 +161,7 @@ class BootstrapTest extends TestCase
     {
         $this->subject->configure();
 
-        self::assertInstanceOf(ContainerInterface::class, $this->subject->getContainer());
+        static::assertInstanceOf(ContainerInterface::class, $this->subject->getContainer());
     }
 
     /**
@@ -181,6 +181,6 @@ class BootstrapTest extends TestCase
     {
         $this->subject->configure();
 
-        self::assertInstanceOf(EntityManagerInterface::class, $this->subject->getEntityManager());
+        static::assertInstanceOf(EntityManagerInterface::class, $this->subject->getEntityManager());
     }
 }

--- a/Tests/Unit/Core/EnvironmentTest.php
+++ b/Tests/Unit/Core/EnvironmentTest.php
@@ -18,7 +18,7 @@ class EnvironmentTest extends TestCase
      */
     public function defaultEnvironmentIsProduction()
     {
-        self::assertSame(Environment::PRODUCTION, Environment::DEFAULT_ENVIRONMENT);
+        static::assertSame(Environment::PRODUCTION, Environment::DEFAULT_ENVIRONMENT);
     }
 
     /**
@@ -44,7 +44,7 @@ class EnvironmentTest extends TestCase
 
         // This is to avoid a warning in PHPUnit that this test has no assertions (as there is no assertion
         // for "no exception is thrown").
-        self::assertTrue(true);
+        static::assertTrue(true);
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Identity/AdministratorTest.php
+++ b/Tests/Unit/Domain/Model/Identity/AdministratorTest.php
@@ -33,7 +33,7 @@ class AdministratorTest extends TestCase
      */
     public function getIdInitiallyReturnsZero()
     {
-        self::assertSame(0, $this->subject->getId());
+        static::assertSame(0, $this->subject->getId());
     }
 
     /**
@@ -44,7 +44,7 @@ class AdministratorTest extends TestCase
         $id = 123456;
         $this->setSubjectId($id);
 
-        self::assertSame($id, $this->subject->getId());
+        static::assertSame($id, $this->subject->getId());
     }
 
     /**
@@ -52,7 +52,7 @@ class AdministratorTest extends TestCase
      */
     public function getLoginNameInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getLoginName());
+        static::assertSame('', $this->subject->getLoginName());
     }
 
     /**
@@ -63,7 +63,7 @@ class AdministratorTest extends TestCase
         $value = 'jane.doe';
         $this->subject->setLoginName($value);
 
-        self::assertSame($value, $this->subject->getLoginName());
+        static::assertSame($value, $this->subject->getLoginName());
     }
 
     /**
@@ -71,7 +71,7 @@ class AdministratorTest extends TestCase
      */
     public function getEmailAddressInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getEmailAddress());
+        static::assertSame('', $this->subject->getEmailAddress());
     }
 
     /**
@@ -82,7 +82,7 @@ class AdministratorTest extends TestCase
         $value = 'oliver@example.com';
         $this->subject->setEmailAddress($value);
 
-        self::assertSame($value, $this->subject->getEmailAddress());
+        static::assertSame($value, $this->subject->getEmailAddress());
     }
 
     /**
@@ -90,7 +90,7 @@ class AdministratorTest extends TestCase
      */
     public function getCreationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getCreationDate());
+        static::assertNull($this->subject->getCreationDate());
     }
 
     /**
@@ -100,7 +100,7 @@ class AdministratorTest extends TestCase
     {
         $this->subject->updateCreationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
     }
 
     /**
@@ -108,7 +108,7 @@ class AdministratorTest extends TestCase
      */
     public function getModificationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getModificationDate());
+        static::assertNull($this->subject->getModificationDate());
     }
 
     /**
@@ -118,7 +118,7 @@ class AdministratorTest extends TestCase
     {
         $this->subject->updateModificationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getModificationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getModificationDate());
     }
 
     /**
@@ -126,7 +126,7 @@ class AdministratorTest extends TestCase
      */
     public function getPasswordHashInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getPasswordHash());
+        static::assertSame('', $this->subject->getPasswordHash());
     }
 
     /**
@@ -137,7 +137,7 @@ class AdministratorTest extends TestCase
         $value = 'Club-Mate';
         $this->subject->setPasswordHash($value);
 
-        self::assertSame($value, $this->subject->getPasswordHash());
+        static::assertSame($value, $this->subject->getPasswordHash());
     }
 
     /**
@@ -145,7 +145,7 @@ class AdministratorTest extends TestCase
      */
     public function getPasswordChangeDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getPasswordChangeDate());
+        static::assertNull($this->subject->getPasswordChangeDate());
     }
 
     /**
@@ -156,7 +156,7 @@ class AdministratorTest extends TestCase
         $date = new \DateTime();
         $this->subject->setPasswordHash('Zaphod Beeblebrox');
 
-        self::assertSimilarDates($date, $this->subject->getPasswordChangeDate());
+        static::assertSimilarDates($date, $this->subject->getPasswordChangeDate());
     }
 
     /**
@@ -164,7 +164,7 @@ class AdministratorTest extends TestCase
      */
     public function isDisabledInitiallyReturnsFalse()
     {
-        self::assertFalse($this->subject->isDisabled());
+        static::assertFalse($this->subject->isDisabled());
     }
 
     /**
@@ -174,7 +174,7 @@ class AdministratorTest extends TestCase
     {
         $this->subject->setDisabled(true);
 
-        self::assertTrue($this->subject->isDisabled());
+        static::assertTrue($this->subject->isDisabled());
     }
 
     /**
@@ -182,7 +182,7 @@ class AdministratorTest extends TestCase
      */
     public function isSuperUserInitiallyReturnsFalse()
     {
-        self::assertFalse($this->subject->isSuperUser());
+        static::assertFalse($this->subject->isSuperUser());
     }
 
     /**
@@ -192,6 +192,6 @@ class AdministratorTest extends TestCase
     {
         $this->subject->setSuperUser(true);
 
-        self::assertTrue($this->subject->isSuperUser());
+        static::assertTrue($this->subject->isSuperUser());
     }
 }

--- a/Tests/Unit/Domain/Model/Identity/AdministratorTokenTest.php
+++ b/Tests/Unit/Domain/Model/Identity/AdministratorTokenTest.php
@@ -34,7 +34,7 @@ class AdministratorTokenTest extends TestCase
      */
     public function getIdInitiallyReturnsZero()
     {
-        self::assertSame(0, $this->subject->getId());
+        static::assertSame(0, $this->subject->getId());
     }
 
     /**
@@ -45,7 +45,7 @@ class AdministratorTokenTest extends TestCase
         $id = 123456;
         $this->setSubjectId($id);
 
-        self::assertSame($id, $this->subject->getId());
+        static::assertSame($id, $this->subject->getId());
     }
 
     /**
@@ -53,7 +53,7 @@ class AdministratorTokenTest extends TestCase
      */
     public function getCreationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getCreationDate());
+        static::assertNull($this->subject->getCreationDate());
     }
 
     /**
@@ -63,7 +63,7 @@ class AdministratorTokenTest extends TestCase
     {
         $this->subject->updateCreationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
     }
 
     /**
@@ -71,7 +71,7 @@ class AdministratorTokenTest extends TestCase
      */
     public function getKeyInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getKey());
+        static::assertSame('', $this->subject->getKey());
     }
 
     /**
@@ -82,7 +82,7 @@ class AdministratorTokenTest extends TestCase
         $value = 'Club-Mate';
         $this->subject->setKey($value);
 
-        self::assertSame($value, $this->subject->getKey());
+        static::assertSame($value, $this->subject->getKey());
     }
 
     /**
@@ -90,7 +90,7 @@ class AdministratorTokenTest extends TestCase
      */
     public function getExpiryInitiallyReturnsDateTime()
     {
-        self::assertInstanceOf(\DateTime::class, $this->subject->getExpiry());
+        static::assertInstanceOf(\DateTime::class, $this->subject->getExpiry());
     }
 
     /**
@@ -100,7 +100,7 @@ class AdministratorTokenTest extends TestCase
     {
         $this->subject->generateExpiry();
 
-        self::assertSimilarDates(new \DateTime('+1 hour'), $this->subject->getExpiry());
+        static::assertSimilarDates(new \DateTime('+1 hour'), $this->subject->getExpiry());
     }
 
     /**
@@ -110,7 +110,7 @@ class AdministratorTokenTest extends TestCase
     {
         $this->subject->generateKey();
 
-        self::assertRegExp('/^[a-z0-9]{32}$/', $this->subject->getKey());
+        static::assertRegExp('/^[a-z0-9]{32}$/', $this->subject->getKey());
     }
 
     /**
@@ -124,7 +124,7 @@ class AdministratorTokenTest extends TestCase
         $this->subject->generateKey();
         $secondKey = $this->subject->getKey();
 
-        self::assertNotSame($firstKey, $secondKey);
+        static::assertNotSame($firstKey, $secondKey);
     }
 
     /**
@@ -132,7 +132,7 @@ class AdministratorTokenTest extends TestCase
      */
     public function getAdministratorInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getAdministrator());
+        static::assertNull($this->subject->getAdministrator());
     }
 
     /**
@@ -143,6 +143,6 @@ class AdministratorTokenTest extends TestCase
         $model = new Administrator();
         $this->subject->setAdministrator($model);
 
-        self::assertSame($model, $this->subject->getAdministrator());
+        static::assertSame($model, $this->subject->getAdministrator());
     }
 }

--- a/Tests/Unit/Domain/Model/Messaging/SubscriberListTest.php
+++ b/Tests/Unit/Domain/Model/Messaging/SubscriberListTest.php
@@ -36,7 +36,7 @@ class SubscriberListTest extends TestCase
      */
     public function getIdInitiallyReturnsZero()
     {
-        self::assertSame(0, $this->subject->getId());
+        static::assertSame(0, $this->subject->getId());
     }
 
     /**
@@ -47,7 +47,7 @@ class SubscriberListTest extends TestCase
         $id = 123456;
         $this->setSubjectId($id);
 
-        self::assertSame($id, $this->subject->getId());
+        static::assertSame($id, $this->subject->getId());
     }
 
     /**
@@ -55,7 +55,7 @@ class SubscriberListTest extends TestCase
      */
     public function getCreationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getCreationDate());
+        static::assertNull($this->subject->getCreationDate());
     }
 
     /**
@@ -65,7 +65,7 @@ class SubscriberListTest extends TestCase
     {
         $this->subject->updateCreationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
     }
 
     /**
@@ -73,7 +73,7 @@ class SubscriberListTest extends TestCase
      */
     public function getModificationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getModificationDate());
+        static::assertNull($this->subject->getModificationDate());
     }
 
     /**
@@ -83,7 +83,7 @@ class SubscriberListTest extends TestCase
     {
         $this->subject->updateModificationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getModificationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getModificationDate());
     }
 
     /**
@@ -91,7 +91,7 @@ class SubscriberListTest extends TestCase
      */
     public function getNameInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getName());
+        static::assertSame('', $this->subject->getName());
     }
 
     /**
@@ -102,7 +102,7 @@ class SubscriberListTest extends TestCase
         $value = 'phpList releases';
         $this->subject->setName($value);
 
-        self::assertSame($value, $this->subject->getName());
+        static::assertSame($value, $this->subject->getName());
     }
 
     /**
@@ -110,7 +110,7 @@ class SubscriberListTest extends TestCase
      */
     public function getDescriptionInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getDescription());
+        static::assertSame('', $this->subject->getDescription());
     }
 
     /**
@@ -121,7 +121,7 @@ class SubscriberListTest extends TestCase
         $value = 'Subscribe to this list when you would like to be notified of new phpList releases.';
         $this->subject->setDescription($value);
 
-        self::assertSame($value, $this->subject->getDescription());
+        static::assertSame($value, $this->subject->getDescription());
     }
 
     /**
@@ -129,7 +129,7 @@ class SubscriberListTest extends TestCase
      */
     public function getListPositionInitiallyReturnsZero()
     {
-        self::assertSame(0, $this->subject->getListPosition());
+        static::assertSame(0, $this->subject->getListPosition());
     }
 
     /**
@@ -140,7 +140,7 @@ class SubscriberListTest extends TestCase
         $value = 123456;
         $this->subject->setListPosition($value);
 
-        self::assertSame($value, $this->subject->getListPosition());
+        static::assertSame($value, $this->subject->getListPosition());
     }
 
     /**
@@ -148,7 +148,7 @@ class SubscriberListTest extends TestCase
      */
     public function getSubjectPrefixInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getSubjectPrefix());
+        static::assertSame('', $this->subject->getSubjectPrefix());
     }
 
     /**
@@ -159,7 +159,7 @@ class SubscriberListTest extends TestCase
         $value = 'Club-Mate';
         $this->subject->setSubjectPrefix($value);
 
-        self::assertSame($value, $this->subject->getSubjectPrefix());
+        static::assertSame($value, $this->subject->getSubjectPrefix());
     }
 
     /**
@@ -167,7 +167,7 @@ class SubscriberListTest extends TestCase
      */
     public function isPublicInitiallyReturnsFalse()
     {
-        self::assertFalse($this->subject->isPublic());
+        static::assertFalse($this->subject->isPublic());
     }
 
     /**
@@ -177,7 +177,7 @@ class SubscriberListTest extends TestCase
     {
         $this->subject->setPublic(true);
 
-        self::assertTrue($this->subject->isPublic());
+        static::assertTrue($this->subject->isPublic());
     }
 
     /**
@@ -185,7 +185,7 @@ class SubscriberListTest extends TestCase
      */
     public function getCategoryInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getCategory());
+        static::assertSame('', $this->subject->getCategory());
     }
 
     /**
@@ -196,7 +196,7 @@ class SubscriberListTest extends TestCase
         $value = 'Club-Mate';
         $this->subject->setCategory($value);
 
-        self::assertSame($value, $this->subject->getCategory());
+        static::assertSame($value, $this->subject->getCategory());
     }
 
     /**
@@ -204,7 +204,7 @@ class SubscriberListTest extends TestCase
      */
     public function getOwnerInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getOwner());
+        static::assertNull($this->subject->getOwner());
     }
 
     /**
@@ -215,7 +215,7 @@ class SubscriberListTest extends TestCase
         $model = new Administrator();
         $this->subject->setOwner($model);
 
-        self::assertSame($model, $this->subject->getOwner());
+        static::assertSame($model, $this->subject->getOwner());
     }
 
     /**
@@ -225,8 +225,8 @@ class SubscriberListTest extends TestCase
     {
         $result = $this->subject->getSubscriptions();
 
-        self::assertInstanceOf(Collection::class, $result);
-        self::assertTrue($result->isEmpty());
+        static::assertInstanceOf(Collection::class, $result);
+        static::assertTrue($result->isEmpty());
     }
 
     /**
@@ -238,7 +238,7 @@ class SubscriberListTest extends TestCase
 
         $this->subject->setSubscriptions($subscriptions);
 
-        self::assertSame($subscriptions, $this->subject->getSubscriptions());
+        static::assertSame($subscriptions, $this->subject->getSubscriptions());
     }
 
     /**
@@ -248,8 +248,8 @@ class SubscriberListTest extends TestCase
     {
         $result = $this->subject->getSubscribers();
 
-        self::assertInstanceOf(Collection::class, $result);
-        self::assertTrue($result->isEmpty());
+        static::assertInstanceOf(Collection::class, $result);
+        static::assertTrue($result->isEmpty());
     }
 
     /**
@@ -261,6 +261,6 @@ class SubscriberListTest extends TestCase
 
         $this->subject->setSubscribers($subscriptions);
 
-        self::assertSame($subscriptions, $this->subject->getSubscribers());
+        static::assertSame($subscriptions, $this->subject->getSubscribers());
     }
 }

--- a/Tests/Unit/Domain/Model/Subscription/SubscriberTest.php
+++ b/Tests/Unit/Domain/Model/Subscription/SubscriberTest.php
@@ -35,7 +35,7 @@ class SubscriberTest extends TestCase
      */
     public function getIdInitiallyReturnsZero()
     {
-        self::assertSame(0, $this->subject->getId());
+        static::assertSame(0, $this->subject->getId());
     }
 
     /**
@@ -46,7 +46,7 @@ class SubscriberTest extends TestCase
         $id = 123456;
         $this->setSubjectId($id);
 
-        self::assertSame($id, $this->subject->getId());
+        static::assertSame($id, $this->subject->getId());
     }
 
     /**
@@ -54,7 +54,7 @@ class SubscriberTest extends TestCase
      */
     public function getCreationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getCreationDate());
+        static::assertNull($this->subject->getCreationDate());
     }
 
     /**
@@ -64,7 +64,7 @@ class SubscriberTest extends TestCase
     {
         $this->subject->updateCreationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
     }
 
     /**
@@ -72,7 +72,7 @@ class SubscriberTest extends TestCase
      */
     public function getModificationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getModificationDate());
+        static::assertNull($this->subject->getModificationDate());
     }
 
     /**
@@ -82,7 +82,7 @@ class SubscriberTest extends TestCase
     {
         $this->subject->updateModificationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getModificationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getModificationDate());
     }
 
     /**
@@ -90,7 +90,7 @@ class SubscriberTest extends TestCase
      */
     public function getEmailInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getEmail());
+        static::assertSame('', $this->subject->getEmail());
     }
 
     /**
@@ -101,7 +101,7 @@ class SubscriberTest extends TestCase
         $value = 'Club-Mate';
         $this->subject->setEmail($value);
 
-        self::assertSame($value, $this->subject->getEmail());
+        static::assertSame($value, $this->subject->getEmail());
     }
 
     /**
@@ -109,7 +109,7 @@ class SubscriberTest extends TestCase
      */
     public function isConfirmedInitiallyReturnsFalse()
     {
-        self::assertFalse($this->subject->isConfirmed());
+        static::assertFalse($this->subject->isConfirmed());
     }
 
     /**
@@ -119,7 +119,7 @@ class SubscriberTest extends TestCase
     {
         $this->subject->setConfirmed(true);
 
-        self::assertTrue($this->subject->isConfirmed());
+        static::assertTrue($this->subject->isConfirmed());
     }
 
     /**
@@ -127,7 +127,7 @@ class SubscriberTest extends TestCase
      */
     public function isBlacklistedInitiallyReturnsFalse()
     {
-        self::assertFalse($this->subject->isBlacklisted());
+        static::assertFalse($this->subject->isBlacklisted());
     }
 
     /**
@@ -137,7 +137,7 @@ class SubscriberTest extends TestCase
     {
         $this->subject->setBlacklisted(true);
 
-        self::assertTrue($this->subject->isBlacklisted());
+        static::assertTrue($this->subject->isBlacklisted());
     }
 
     /**
@@ -145,7 +145,7 @@ class SubscriberTest extends TestCase
      */
     public function getBounceCountInitiallyReturnsZero()
     {
-        self::assertSame(0, $this->subject->getBounceCount());
+        static::assertSame(0, $this->subject->getBounceCount());
     }
 
     /**
@@ -156,7 +156,7 @@ class SubscriberTest extends TestCase
         $value = 123456;
         $this->subject->setBounceCount($value);
 
-        self::assertSame($value, $this->subject->getBounceCount());
+        static::assertSame($value, $this->subject->getBounceCount());
     }
 
     /**
@@ -170,7 +170,7 @@ class SubscriberTest extends TestCase
 
         $this->subject->addToBounceCount($delta);
 
-        self::assertSame($initialValue + $delta, $this->subject->getBounceCount());
+        static::assertSame($initialValue + $delta, $this->subject->getBounceCount());
     }
 
     /**
@@ -178,7 +178,7 @@ class SubscriberTest extends TestCase
      */
     public function getUniqueIdInitiallyReturnsEmptyString()
     {
-        self::assertSame('', $this->subject->getUniqueId());
+        static::assertSame('', $this->subject->getUniqueId());
     }
 
     /**
@@ -189,7 +189,7 @@ class SubscriberTest extends TestCase
         $value = 'Club-Mate';
         $this->subject->setUniqueId($value);
 
-        self::assertSame($value, $this->subject->getUniqueId());
+        static::assertSame($value, $this->subject->getUniqueId());
     }
 
     /**
@@ -199,7 +199,7 @@ class SubscriberTest extends TestCase
     {
         $this->subject->generateUniqueId();
 
-        self::assertRegExp('/^[0-9a-f]{32}$/', $this->subject->getUniqueId());
+        static::assertRegExp('/^[0-9a-f]{32}$/', $this->subject->getUniqueId());
     }
 
     /**
@@ -207,7 +207,7 @@ class SubscriberTest extends TestCase
      */
     public function hasHtmlEmailInitiallyReturnsFalse()
     {
-        self::assertFalse($this->subject->hasHtmlEmail());
+        static::assertFalse($this->subject->hasHtmlEmail());
     }
 
     /**
@@ -217,7 +217,7 @@ class SubscriberTest extends TestCase
     {
         $this->subject->setHtmlEmail(true);
 
-        self::assertTrue($this->subject->hasHtmlEmail());
+        static::assertTrue($this->subject->hasHtmlEmail());
     }
 
     /**
@@ -225,7 +225,7 @@ class SubscriberTest extends TestCase
      */
     public function isDisabledInitiallyReturnsFalse()
     {
-        self::assertFalse($this->subject->isDisabled());
+        static::assertFalse($this->subject->isDisabled());
     }
 
     /**
@@ -235,7 +235,7 @@ class SubscriberTest extends TestCase
     {
         $this->subject->setDisabled(true);
 
-        self::assertTrue($this->subject->isDisabled());
+        static::assertTrue($this->subject->isDisabled());
     }
 
     /**
@@ -245,8 +245,8 @@ class SubscriberTest extends TestCase
     {
         $result = $this->subject->getSubscriptions();
 
-        self::assertInstanceOf(Collection::class, $result);
-        self::assertTrue($result->isEmpty());
+        static::assertInstanceOf(Collection::class, $result);
+        static::assertTrue($result->isEmpty());
     }
 
     /**
@@ -258,7 +258,7 @@ class SubscriberTest extends TestCase
 
         $this->subject->setSubscriptions($subscriptions);
 
-        self::assertSame($subscriptions, $this->subject->getSubscriptions());
+        static::assertSame($subscriptions, $this->subject->getSubscriptions());
     }
 
     /**
@@ -268,8 +268,8 @@ class SubscriberTest extends TestCase
     {
         $result = $this->subject->getSubscribedLists();
 
-        self::assertInstanceOf(Collection::class, $result);
-        self::assertTrue($result->isEmpty());
+        static::assertInstanceOf(Collection::class, $result);
+        static::assertTrue($result->isEmpty());
     }
 
     /**
@@ -281,6 +281,6 @@ class SubscriberTest extends TestCase
 
         $this->subject->setSubscribedLists($subscriptions);
 
-        self::assertSame($subscriptions, $this->subject->getSubscribedLists());
+        static::assertSame($subscriptions, $this->subject->getSubscribedLists());
     }
 }

--- a/Tests/Unit/Domain/Model/Subscription/SubscriptionTest.php
+++ b/Tests/Unit/Domain/Model/Subscription/SubscriptionTest.php
@@ -35,7 +35,7 @@ class SubscriptionTest extends TestCase
      */
     public function getSubscriberInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getSubscriber());
+        static::assertNull($this->subject->getSubscriber());
     }
 
     /**
@@ -46,7 +46,7 @@ class SubscriptionTest extends TestCase
         $model = new Subscriber();
         $this->subject->setSubscriber($model);
 
-        self::assertSame($model, $this->subject->getSubscriber());
+        static::assertSame($model, $this->subject->getSubscriber());
     }
 
     /**
@@ -54,7 +54,7 @@ class SubscriptionTest extends TestCase
      */
     public function getSubscriberListInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getSubscriberList());
+        static::assertNull($this->subject->getSubscriberList());
     }
 
     /**
@@ -65,7 +65,7 @@ class SubscriptionTest extends TestCase
         $model = new SubscriberList();
         $this->subject->setSubscriberList($model);
 
-        self::assertSame($model, $this->subject->getSubscriberList());
+        static::assertSame($model, $this->subject->getSubscriberList());
     }
 
     /**
@@ -73,7 +73,7 @@ class SubscriptionTest extends TestCase
      */
     public function getCreationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getCreationDate());
+        static::assertNull($this->subject->getCreationDate());
     }
 
     /**
@@ -83,7 +83,7 @@ class SubscriptionTest extends TestCase
     {
         $this->subject->updateCreationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getCreationDate());
     }
 
     /**
@@ -91,7 +91,7 @@ class SubscriptionTest extends TestCase
      */
     public function getModificationDateInitiallyReturnsNull()
     {
-        self::assertNull($this->subject->getModificationDate());
+        static::assertNull($this->subject->getModificationDate());
     }
 
     /**
@@ -101,6 +101,6 @@ class SubscriptionTest extends TestCase
     {
         $this->subject->updateModificationDate();
 
-        self::assertSimilarDates(new \DateTime(), $this->subject->getModificationDate());
+        static::assertSimilarDates(new \DateTime(), $this->subject->getModificationDate());
     }
 }

--- a/Tests/Unit/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -36,6 +36,6 @@ class AdministratorRepositoryTest extends TestCase
      */
     public function classIsEntityRepository()
     {
-        self::assertInstanceOf(EntityRepository::class, $this->subject);
+        static::assertInstanceOf(EntityRepository::class, $this->subject);
     }
 }

--- a/Tests/Unit/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -36,6 +36,6 @@ class AdministratorTokenRepositoryTest extends TestCase
      */
     public function classIsEntityRepository()
     {
-        self::assertInstanceOf(EntityRepository::class, $this->subject);
+        static::assertInstanceOf(EntityRepository::class, $this->subject);
     }
 }

--- a/Tests/Unit/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
@@ -36,6 +36,6 @@ class SubscriberListRepositoryTest extends TestCase
      */
     public function classIsEntityRepository()
     {
-        self::assertInstanceOf(EntityRepository::class, $this->subject);
+        static::assertInstanceOf(EntityRepository::class, $this->subject);
     }
 }

--- a/Tests/Unit/Domain/Repository/Subscription/SubscriberRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/Subscription/SubscriberRepositoryTest.php
@@ -36,6 +36,6 @@ class SubscriberRepositoryTest extends TestCase
      */
     public function classIsEntityRepository()
     {
-        self::assertInstanceOf(EntityRepository::class, $this->subject);
+        static::assertInstanceOf(EntityRepository::class, $this->subject);
     }
 }

--- a/Tests/Unit/Domain/Repository/Subscription/SubscriptionRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/Subscription/SubscriptionRepositoryTest.php
@@ -36,6 +36,6 @@ class SubscriptionRepositoryTest extends TestCase
      */
     public function classIsEntityRepository()
     {
-        self::assertInstanceOf(EntityRepository::class, $this->subject);
+        static::assertInstanceOf(EntityRepository::class, $this->subject);
     }
 }

--- a/Tests/Unit/EmptyStartPageBundle/Controller/DefaultControllerTest.php
+++ b/Tests/Unit/EmptyStartPageBundle/Controller/DefaultControllerTest.php
@@ -30,7 +30,7 @@ class DefaultControllerTest extends TestCase
      */
     public function classIsController()
     {
-        self::assertInstanceOf(Controller::class, $this->subject);
+        static::assertInstanceOf(Controller::class, $this->subject);
     }
 
     /**
@@ -41,6 +41,6 @@ class DefaultControllerTest extends TestCase
         $result = $this->subject->indexAction();
 
         $expectedResult = new Response('This page has been intentionally left empty.');
-        self::assertEquals($expectedResult, $result);
+        static::assertEquals($expectedResult, $result);
     }
 }

--- a/Tests/Unit/EmptyStartPageBundle/PhpListEmptyStartPageBundleTest.php
+++ b/Tests/Unit/EmptyStartPageBundle/PhpListEmptyStartPageBundleTest.php
@@ -29,6 +29,6 @@ class PhpListEmptyStartPageBundleTest extends TestCase
      */
     public function classIsBundle()
     {
-        self::assertInstanceOf(Bundle::class, $this->subject);
+        static::assertInstanceOf(Bundle::class, $this->subject);
     }
 }

--- a/Tests/Unit/Routing/ExtraLoaderTest.php
+++ b/Tests/Unit/Routing/ExtraLoaderTest.php
@@ -36,7 +36,7 @@ class ExtraLoaderTest extends TestCase
      */
     public function classIsLoader()
     {
-        self::assertInstanceOf(Loader::class, $this->subject);
+        static::assertInstanceOf(Loader::class, $this->subject);
     }
 
     /**
@@ -44,7 +44,7 @@ class ExtraLoaderTest extends TestCase
      */
     public function supportsExtraType()
     {
-        self::assertTrue($this->subject->supports('', 'extra'));
+        static::assertTrue($this->subject->supports('', 'extra'));
     }
 
     /**
@@ -52,6 +52,6 @@ class ExtraLoaderTest extends TestCase
      */
     public function notSupportsOtherType()
     {
-        self::assertFalse($this->subject->supports('', 'foo'));
+        static::assertFalse($this->subject->supports('', 'foo'));
     }
 }

--- a/Tests/Unit/Security/AuthenticationTest.php
+++ b/Tests/Unit/Security/AuthenticationTest.php
@@ -53,7 +53,7 @@ class AuthenticationTest extends TestCase
 
         $this->tokenRepositoryProphecy->findOneUnexpiredByKey($apiKey)->willReturn($token)->shouldBeCalled();
 
-        self::assertSame($administrator, $this->subject->authenticateByApiKey($request));
+        static::assertSame($administrator, $this->subject->authenticateByApiKey($request));
     }
 
     /**
@@ -69,7 +69,7 @@ class AuthenticationTest extends TestCase
 
         $this->tokenRepositoryProphecy->findOneUnexpiredByKey($apiKey)->willReturn($token)->shouldBeCalled();
 
-        self::assertNull($this->subject->authenticateByApiKey($request));
+        static::assertNull($this->subject->authenticateByApiKey($request));
     }
 
     /**
@@ -83,7 +83,7 @@ class AuthenticationTest extends TestCase
 
         $this->tokenRepositoryProphecy->findOneUnexpiredByKey($apiKey)->willReturn(null)->shouldBeCalled();
 
-        self::assertNull($this->subject->authenticateByApiKey($request));
+        static::assertNull($this->subject->authenticateByApiKey($request));
     }
 
     /**
@@ -94,7 +94,7 @@ class AuthenticationTest extends TestCase
         $request = new Request();
         $request->headers->add(['php-auth-pw' => '']);
 
-        self::assertNull($this->subject->authenticateByApiKey($request));
+        static::assertNull($this->subject->authenticateByApiKey($request));
     }
 
     /**
@@ -104,6 +104,6 @@ class AuthenticationTest extends TestCase
     {
         $request = new Request();
 
-        self::assertNull($this->subject->authenticateByApiKey($request));
+        static::assertNull($this->subject->authenticateByApiKey($request));
     }
 }

--- a/Tests/Unit/Security/HashGeneratorTest.php
+++ b/Tests/Unit/Security/HashGeneratorTest.php
@@ -28,7 +28,7 @@ class HashGeneratorTest extends TestCase
      */
     public function createPasswordHashCreates32ByteHash()
     {
-        self::assertRegExp('/^[a-z0-9]{64}$/', $this->subject->createPasswordHash('Portal'));
+        static::assertRegExp('/^[a-z0-9]{64}$/', $this->subject->createPasswordHash('Portal'));
     }
 
     /**
@@ -38,7 +38,10 @@ class HashGeneratorTest extends TestCase
     {
         $password = 'Aperture Science';
 
-        self::assertSame($this->subject->createPasswordHash($password), $this->subject->createPasswordHash($password));
+        static::assertSame(
+            $this->subject->createPasswordHash($password),
+            $this->subject->createPasswordHash($password)
+        );
     }
 
     /**
@@ -46,7 +49,7 @@ class HashGeneratorTest extends TestCase
      */
     public function createPasswordHashCalledTwoTimesWithDifferentPasswordsCreatesDifferentHashes()
     {
-        self::assertNotSame(
+        static::assertNotSame(
             $this->subject->createPasswordHash('Mel'),
             $this->subject->createPasswordHash('Cave Johnson')
         );

--- a/core/helper/Process.php
+++ b/core/helper/Process.php
@@ -33,7 +33,7 @@ class Process
             );
         }
 
-        $running_processes = self::getRunningProcesses($page);
+        $running_processes = static::getRunningProcesses($page);
 
         phpList::log()->info($running_processes['count'] . ' out of ' . $max . ' active processes', ['page' => 'process']);
         $waited = 0;


### PR DESCRIPTION
This will allow for subclasses to overwrite methods and constants and hence
is the current recommended practice.