### PR TITLE
[CLEANUP] Always use touchDatabaseTable in the integration tests

### DIFF
--- a/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -107,8 +107,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
-        $this->applyDatabaseChanges();
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new Administrator();
         $expectedCreationDate = new \DateTime();
@@ -123,8 +122,7 @@ class AdministratorRepositoryTest extends AbstractDatabaseTest
      */
     public function modificationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
-        $this->applyDatabaseChanges();
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new Administrator();
         $expectedModificationDate = new \DateTime();

--- a/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -112,8 +112,7 @@ class AdministratorTokenRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
-        $this->applyDatabaseChanges();
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new Administrator();
         $expectedCreationDate = new \DateTime();

--- a/Tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
+++ b/Tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
@@ -122,8 +122,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function creationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
-        $this->applyDatabaseChanges();
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new SubscriberList();
         $expectedCreationDate = new \DateTime();
@@ -138,8 +137,7 @@ class SubscriberListRepositoryTest extends AbstractDatabaseTest
      */
     public function modificationDateOfNewModelIsSetToNowOnPersist()
     {
-        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
-        $this->applyDatabaseChanges();
+        $this->touchDatabaseTable(static::TABLE_NAME);
 
         $model = new SubscriberList();
         $expectedModificationDate = new \DateTime();


### PR DESCRIPTION
After the fixes for properly truncating tables in the tests, touchDatabaseTable works fine and can always be used.