### PR TITLE
[BUGFIX] Cascading removal of subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Remove associated subscriptions when a subscriber list or subscriber is removed (#271)
 - Always truncate the DB tables after an integration test (#259)
 - Adapt the system tests to possible HTTP errors (#256)
 

--- a/src/Domain/Model/Messaging/SubscriberList.php
+++ b/src/Domain/Model/Messaging/SubscriberList.php
@@ -106,7 +106,11 @@ class SubscriberList implements Identity, CreationDate, ModificationDate
 
     /**
      * @var Collection
-     * @OneToMany(targetEntity="PhpList\PhpList4\Domain\Model\Subscription\Subscription", mappedBy="subscriberList")
+     * @OneToMany(
+     *     targetEntity="PhpList\PhpList4\Domain\Model\Subscription\Subscription",
+     *     mappedBy="subscriberList",
+     *     cascade={"remove"}
+     * )
      */
     private $subscriptions = null;
 

--- a/src/Domain/Model/Subscription/Subscriber.php
+++ b/src/Domain/Model/Subscription/Subscriber.php
@@ -107,7 +107,11 @@ class Subscriber implements Identity, CreationDate, ModificationDate
 
     /**
      * @var Collection
-     * @OneToMany(targetEntity="PhpList\PhpList4\Domain\Model\Subscription\Subscription", mappedBy="subscriber")
+     * @OneToMany(
+     *     targetEntity="PhpList\PhpList4\Domain\Model\Subscription\Subscription",
+     *     mappedBy="subscriber",
+     *     cascade={"remove"}
+     *  )
      */
     private $subscriptions = null;
 


### PR DESCRIPTION
When a subscriber or a subscriber list is removed, all associated
subscriptions need to be removed as well.