### PR TITLE
[FOLLOWUP] Use correct association count in tests for cascading removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Remove associated subscriptions when a subscriber list or subscriber is removed (#271)
+- Remove associated subscriptions when a subscriber list or subscriber is removed (#271, #272)
 - Always truncate the DB tables after an integration test (#259)
 - Adapt the system tests to possible HTTP errors (#256)
 

--- a/tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
+++ b/tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
@@ -288,6 +288,6 @@ class SubscriberListRepositoryTest extends TestCase
 
         $newNumberOfSubscriptions = count($this->subscriptionRepository->findAll());
         $numberOfRemovedSubscriptions = $initialNumberOfSubscriptions - $newNumberOfSubscriptions;
-        static::assertSame($numberOfAssociatedSubscriptions, $newNumberOfSubscriptions);
+        static::assertSame($numberOfAssociatedSubscriptions, $numberOfRemovedSubscriptions);
     }
 }

--- a/tests/Integration/Domain/Repository/Subscription/SubscriberRepositoryTest.php
+++ b/tests/Integration/Domain/Repository/Subscription/SubscriberRepositoryTest.php
@@ -293,6 +293,6 @@ class SubscriberRepositoryTest extends TestCase
 
         $newNumberOfSubscriptions = count($this->subscriptionRepository->findAll());
         $numberOfRemovedSubscriptions = $initialNumberOfSubscriptions - $newNumberOfSubscriptions;
-        static::assertSame($numberOfAssociatedSubscriptions, $newNumberOfSubscriptions);
+        static::assertSame($numberOfAssociatedSubscriptions, $numberOfRemovedSubscriptions);
     }
 }


### PR DESCRIPTION
The tests used the wrong variable names and only were green
by pure coincidence.
